### PR TITLE
UX improvements: map markers, popups, menus, and visual system

### DIFF
--- a/website/src/App.svelte
+++ b/website/src/App.svelte
@@ -17,6 +17,16 @@
     setStateFromURLParams,
   } from "./lib/appState.svelte";
 
+  type UrlState = {
+    location?: { lat: number; lon: number };
+    zoom?: number;
+  };
+  type MapTravel = (options: {
+    location: { lat: number; lon: number };
+    zoom?: number;
+    flyDuration: number;
+  }) => void;
+
   let isNarrowScreen = $state(false);
 
   // -------------------------
@@ -34,15 +44,18 @@
    * Initialize app state from URL parameters
    */
   function setStateFromURLParamsAndMoveMap() {
-    const urlState = setStateFromURLParams();
+    const urlState = setStateFromURLParams() as UrlState;
+    const mapTravel = uiGlobals.mapTravel as MapTravel | null;
+    if (!mapTravel) return;
+
     if (urlState.location) {
-      uiGlobals.mapTravel({
+      mapTravel({
         location: urlState.location,
         zoom: urlState.zoom,
         flyDuration: 0.3,
       });
     } else {
-      uiGlobals.mapTravel({
+      mapTravel({
         location: { lat: 48, lon: 0 },
         zoom: 4,
         flyDuration: 0,
@@ -84,7 +97,13 @@
   <div class="content-container">
     {#if appState.wikiPage || appState.paneTab === "same-location-events" || appState.paneTab === "about"}
       <div class="wiki-pane-container">
-        <SlidingPane />
+        {#if isNarrowScreen}
+          {#key appState.wikiPage}
+            <SlidingPane />
+          {/key}
+        {:else}
+          <SlidingPane />
+        {/if}
       </div>
     {/if}
 
@@ -136,8 +155,10 @@
   }
 
   main.narrow-screen .wiki-pane-container {
-    flex: 0 0 0;
-    order: 2; /* Put wiki pane at the bottom */
+    flex: none;
+    order: 2; /* Pane is fixed on mobile, so it should not resize the map. */
+    height: 0;
+    z-index: 900;
   }
 
   main.narrow-screen .map-container {

--- a/website/src/App.svelte
+++ b/website/src/App.svelte
@@ -181,8 +181,7 @@
     width: 80%;
     max-width: 500px;
     z-index: 1000;
-    background-color: none;
-    border-radius: 20px;
+    border-radius: var(--ln-radius-pill);
     padding: 5px;
   }
 </style>

--- a/website/src/App.svelte
+++ b/website/src/App.svelte
@@ -23,7 +23,6 @@
   // LIFECYCLE HOOKS
   // -------------------------
   onMount(async () => {
-    console.log("App starting!");
     checkForNarrowScreen(); // Initialize mobile detection
     setStateFromURLParamsAndMoveMap();
     window.addEventListener("popstate", setStateFromURLParamsAndMoveMap);
@@ -74,7 +73,7 @@
    */
 </script>
 
-<svelte:window on:resize={checkForNarrowScreen} />
+<svelte:window onresize={checkForNarrowScreen} />
 
 <main
   class:narrow-screen={isNarrowScreen}

--- a/website/src/app.css
+++ b/website/src/app.css
@@ -2,6 +2,56 @@
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+
+  --ln-color-surface: #ffffff;
+  --ln-color-surface-muted: #f8fafc;
+  --ln-color-surface-hover: #f3f4f6;
+  --ln-color-surface-active: #e5e7eb;
+  --ln-color-border: #d1d5db;
+  --ln-color-border-muted: #e5e7eb;
+  --ln-color-border-strong: #a2a9b1;
+
+  --ln-color-text: #202122;
+  --ln-color-text-muted: #54595d;
+  --ln-color-text-subtle: #72777d;
+  --ln-color-icon: #6b7280;
+  --ln-color-icon-muted: #9ca3af;
+
+  --ln-color-primary: #3366cc;
+  --ln-color-primary-hover: #254aa5;
+  --ln-color-primary-active: #1f3f8a;
+  --ln-color-primary-soft: #f0f5ff;
+  --ln-color-focus: #3b82f6;
+  --ln-color-focus-ring: rgba(59, 130, 246, 0.18);
+  --ln-shadow-primary-sm: 0 2px 6px rgba(51, 102, 204, 0.3);
+  --ln-shadow-primary-md: 0 2px 8px rgba(51, 102, 204, 0.35);
+
+  --ln-color-success: #166534;
+  --ln-color-danger: #b91c1c;
+  --ln-color-marker-selected: #e53935;
+  --ln-color-event-count: #f97373;
+  --ln-color-marker-stroke: #2f3437;
+
+  --ln-radius-xs: 2px;
+  --ln-radius-sm: 4px;
+  --ln-radius-md: 6px;
+  --ln-radius-lg: 8px;
+  --ln-radius-xl: 12px;
+  --ln-radius-2xl: 16px;
+  --ln-radius-pill: 999px;
+
+  --ln-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
+  --ln-shadow-md: 0 2px 8px rgba(0, 0, 0, 0.14);
+  --ln-shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.15);
+  --ln-shadow-popup: 0 8px 24px rgba(0, 0, 0, 0.16);
+  --ln-shadow-pane: 2px 0 10px rgba(0, 0, 0, 0.2);
+  --ln-shadow-pane-mobile: 0 -4px 18px rgba(0, 0, 0, 0.22);
+  --ln-shadow-marker: 4px 4px 8px rgba(0, 0, 0, 0.35);
+  --ln-shadow-marker-selected: 6px 6px 14px rgba(0, 0, 0, 0.55);
+
+  --ln-space-touch: 44px;
+  --ln-transition-fast: 0.15s ease;
+  --ln-transition-base: 0.2s ease;
 }
 
 body {
@@ -17,4 +67,19 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
-} 
+}
+
+button,
+[role="button"],
+[role="combobox"],
+input {
+  font: inherit;
+}
+
+button:focus-visible,
+[role="button"]:focus-visible,
+[role="combobox"]:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--ln-color-focus);
+  outline-offset: 2px;
+}

--- a/website/src/lib/appState.svelte.js
+++ b/website/src/lib/appState.svelte.js
@@ -134,7 +134,6 @@ export function updateURLParams(state, addToHistory = true) {
   const newUrl = `${window.location.pathname}?${params.toString()}`;
 
   if (params.toString() === window.location.search.slice(1)) {
-    console.log("Skipping pushstate because the url is the same");
     return;
   }
 

--- a/website/src/lib/data/events_data.js
+++ b/website/src/lib/data/events_data.js
@@ -8,7 +8,6 @@ const cachedEventsById = new Map();
 function initEventsWorker() {
   // Create a single worker instance that will be reused
 
-  console.log("Initializing worker");
   if (worker === null) {
     worker = new Worker(new URL("./events_worker.js", import.meta.url), {
       type: "module",

--- a/website/src/lib/data/mapEntries.svelte.js
+++ b/website/src/lib/data/mapEntries.svelte.js
@@ -22,6 +22,10 @@ export const mapEntries = $state({ markerInfos: [], dots: [] });
 export const mapBounds = $state({});
 
 let cachedPlaceData = new Map();
+let placeEntriesRequestId = 0;
+let eventEntriesRequestId = 0;
+let selectedMarkerRequestId = 0;
+let handledSelectedMarkerId = null;
 
 $effect.root(() => {
   $effect(() => {
@@ -58,29 +62,48 @@ $effect.root(() => {
  * @param {number} options.zoom - The current zoom level of the map
  */
 async function updateMapPlaceEntries({ mapBounds, zoom }) {
+  const requestId = ++placeEntriesRequestId;
   const willBeLoadingTimeOut = setTimeout(() => {
     uiState.dataIsLoading = true;
   }, 500);
-  const { entryInfos, dots } = await getGeodataFromBounds({
-    bounds: mapBounds,
-    maxZoomLevel: zoom - 1,
-    cachedQueries: cachedPlaceData,
-  });
-
-  // Make sure the selected marker is included
-  if (
-    appState.selectedMarkerId &&
-    !entryInfos.some((entry) => entry.geokey === appState.selectedMarkerId)
-  ) {
-    const selectedMarker = await getPlaceDataFromGeokeys({
-      geokeys: [appState.selectedMarkerId],
+  try {
+    const { entryInfos, dots } = await getGeodataFromBounds({
+      bounds: mapBounds,
+      maxZoomLevel: zoom - 1,
       cachedQueries: cachedPlaceData,
     });
-    entryInfos.push(selectedMarker[0]);
+
+    if (requestId !== placeEntriesRequestId || appState.mode !== "places") {
+      return;
+    }
+
+    // Make sure the selected marker is included
+    if (
+      appState.selectedMarkerId &&
+      !entryInfos.some((entry) => entry.geokey === appState.selectedMarkerId)
+    ) {
+      const selectedMarker = await getPlaceDataFromGeokeys({
+        geokeys: [appState.selectedMarkerId],
+        cachedQueries: cachedPlaceData,
+      });
+      if (requestId !== placeEntriesRequestId || appState.mode !== "places") {
+        return;
+      }
+      if (selectedMarker[0]) {
+        entryInfos.push(selectedMarker[0]);
+      }
+    }
+    updateMapEntriesFromQueryResults({ entryInfos, dots });
+  } catch (error) {
+    if (requestId === placeEntriesRequestId) {
+      console.error("Error updating place map entries:", error);
+    }
+  } finally {
+    clearTimeout(willBeLoadingTimeOut);
+    if (requestId === placeEntriesRequestId && appState.mode === "places") {
+      uiState.dataIsLoading = false;
+    }
   }
-  updateMapEntriesFromQueryResults({ entryInfos, dots });
-  clearTimeout(willBeLoadingTimeOut);
-  uiState.dataIsLoading = false;
 }
 
 /**
@@ -93,34 +116,50 @@ async function updateMapPlaceEntries({ mapBounds, zoom }) {
  * @returns {Promise<Object>} - Object containing event information and dots for the map
  */
 async function updateMapEventEntries({ mapBounds, zoom, date, strictDate }) {
+  const requestId = ++eventEntriesRequestId;
   const willBeLoadingTimeOut = setTimeout(() => {
     uiState.dataIsLoading = true;
   }, 500);
-  const { events, dotEvents } = await getEventsForBoundsAndDate({
-    date,
-    bounds: mapBounds,
-    zoom: zoom - 1,
-    strictDate,
-  });
-  const eventIds = events.map((event) => event.event_id);
-  const eventInfos = await getEventsById(eventIds);
-  // Add type annotation to make it clear this is a Map of objects
-  const eventInfosById = new Map(
-    eventInfos.map((eventInfo) => [eventInfo.event_id, eventInfo])
-  );
+  try {
+    const { events, dotEvents } = await getEventsForBoundsAndDate({
+      date,
+      bounds: mapBounds,
+      zoom: zoom - 1,
+      strictDate,
+    });
+    if (requestId !== eventEntriesRequestId || appState.mode !== "events") {
+      return;
+    }
 
-  const eventsWithInfos = events.map((event) => {
-    // Cast to object type or use type assertion
-    const eventInfo = eventInfosById.get(event.event_id) || {};
-    return { ...eventInfo, ...event };
-  });
+    const eventIds = events.map((event) => event.event_id);
+    const eventInfos = await getEventsById(eventIds);
+    if (requestId !== eventEntriesRequestId || appState.mode !== "events") {
+      return;
+    }
 
-  updateMapEntriesFromQueryResults({
-    entryInfos: eventsWithInfos,
-    dots: dotEvents,
-  });
-  clearTimeout(willBeLoadingTimeOut);
-  uiState.dataIsLoading = false;
+    const eventInfosById = new Map(
+      eventInfos.map((eventInfo) => [eventInfo.event_id, eventInfo])
+    );
+
+    const eventsWithInfos = events.map((event) => {
+      const eventInfo = eventInfosById.get(event.event_id) || {};
+      return { ...eventInfo, ...event };
+    });
+
+    updateMapEntriesFromQueryResults({
+      entryInfos: eventsWithInfos,
+      dots: dotEvents,
+    });
+  } catch (error) {
+    if (requestId === eventEntriesRequestId) {
+      console.error("Error updating event map entries:", error);
+    }
+  } finally {
+    clearTimeout(willBeLoadingTimeOut);
+    if (requestId === eventEntriesRequestId && appState.mode === "events") {
+      uiState.dataIsLoading = false;
+    }
+  }
 }
 
 function updateMapEntriesFromQueryResults({ entryInfos, dots }) {
@@ -153,15 +192,20 @@ function updateDisplayClasses(entries) {
 }
 
 async function handleNewSelectedMarker(selectedMarkerId) {
-  if (selectedMarkerId === appState.selectedMarkerId) return;
+  if (selectedMarkerId === handledSelectedMarkerId) return;
+  const requestId = ++selectedMarkerRequestId;
+
   if (!selectedMarkerId) {
+    handledSelectedMarkerId = null;
     // a marker got deselected. Let's just update the display classes
     updateDisplayClasses(mapEntries.markerInfos);
+    mapEntries.markerInfos = [...mapEntries.markerInfos];
     return;
   }
 
+  const selectedMode = appState.mode;
   let query;
-  if (appState.mode === "places") {
+  if (selectedMode === "places") {
     query = await getPlaceDataFromGeokeys({
       geokeys: [selectedMarkerId],
       cachedQueries: cachedPlaceData,
@@ -170,7 +214,17 @@ async function handleNewSelectedMarker(selectedMarkerId) {
     query = await getEventsById([selectedMarkerId]);
   }
 
+  if (
+    requestId !== selectedMarkerRequestId ||
+    selectedMarkerId !== appState.selectedMarkerId ||
+    selectedMode !== appState.mode ||
+    !query[0]
+  ) {
+    return;
+  }
+
   const selectedMarker = normalizeMapEntryInfo(query[0]);
+  handledSelectedMarkerId = selectedMarkerId;
   appState.wikiSection = selectedMarker.page_section;
   appState.wikiPage = selectedMarker.pageTitle;
   appState.paneTab = "wikipedia";

--- a/website/src/lib/data/places_data.js
+++ b/website/src/lib/data/places_data.js
@@ -103,13 +103,11 @@ export async function getGeodataFromBounds({
   // Create a list of dot markers from dots
   const dots = [];
   const seenCoordinates = new Set(); // Track coordinates we've already processed
-  let totalEntries = 0;
   for (const result of geokeyResults) {
     if (!result.dots) continue;
     if (!result.dots[maxZoomLevel]) continue;
     // Process each entry at this zoom level
     for (const entry of result.dots[maxZoomLevel]) {
-      totalEntries++;
       if (seenCoordinates.has(entry.geokey)) continue;
       seenCoordinates.add(entry.geokey);
 

--- a/website/src/lib/map/EventCard.svelte
+++ b/website/src/lib/map/EventCard.svelte
@@ -365,11 +365,11 @@
 
 <style>
   :global(.event-marker-popup .leaflet-popup-content-wrapper) {
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border-radius: var(--ln-radius-lg);
+    box-shadow: var(--ln-shadow-md);
     padding: 0;
     overflow: hidden;
-    background: #fff;
+    background: var(--ln-color-surface);
   }
 
   :global(.event-marker-popup .leaflet-popup-content) {
@@ -382,6 +382,7 @@
       Ubuntu, sans-serif;
     cursor: default;
     overflow-y: auto;
+    color: var(--ln-color-text);
   }
 
   .event-card .event-card-section {
@@ -389,7 +390,7 @@
     align-items: flex-start;
     margin-bottom: 5px;
     padding-bottom: 5px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+    border-bottom: 1px solid var(--ln-color-border-muted);
   }
 
   .event-card .event-card-section:last-child {
@@ -419,26 +420,26 @@
   }
 
   .event-card-section.when .event-text {
-    color: #333;
+    color: var(--ln-color-text);
   }
   .event-card-section.location .event-text {
-    color: #333;
+    color: var(--ln-color-text);
   }
 
   .event-card-section.summary .event-text {
-    color: #333;
+    color: var(--ln-color-text-muted);
     font-style: italic;
   }
 
   .wiki-link {
-    color: #1a73e8 !important;
+    color: var(--ln-color-primary) !important;
     font-weight: 500;
     text-decoration: none;
     cursor: pointer;
   }
 
   .wiki-section {
-    color: #333;
+    color: var(--ln-color-text-muted);
     font-style: italic;
   }
 
@@ -451,43 +452,55 @@
   .event-card-section.go-to-event-button button {
     display: inline-flex;
     align-items: center;
-    background-color: white;
-    border: 1px solid #3366cc;
-    border-radius: 6px;
+    background-color: var(--ln-color-surface);
+    border: 1px solid var(--ln-color-primary);
+    border-radius: var(--ln-radius-md);
     padding: 6px 14px;
+    min-height: 36px;
     font-size: 14px;
-    color: #3366cc;
+    color: var(--ln-color-primary);
     cursor: pointer;
-    transition: all 0.2s ease;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: all var(--ln-transition-base);
+    box-shadow: var(--ln-shadow-sm);
   }
 
   .event-card-section.go-to-event-button button:hover {
-    background-color: #f0f5ff;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    background-color: var(--ln-color-primary-soft);
+    box-shadow: var(--ln-shadow-md);
   }
 
   .event-card-section.go-to-event-button button:focus {
     outline: none;
     box-shadow:
-      0 0 0 2px rgba(51, 102, 204, 0.4),
-      0 1px 3px rgba(0, 0, 0, 0.1);
+      0 0 0 3px var(--ln-color-focus-ring),
+      var(--ln-shadow-sm);
   }
 
   .event-card-section.other-events-button button {
-    background-color: white;
-    border: 1px solid #3366cc;
-    border-radius: 6px;
+    background-color: var(--ln-color-surface);
+    border: 1px solid var(--ln-color-primary);
+    border-radius: var(--ln-radius-md);
+    color: var(--ln-color-primary);
+    padding: 6px 14px;
+    min-height: 36px;
+    transition: all var(--ln-transition-base);
   }
 
   .event-card-section.other-events-button button:hover {
-    background-color: #f0f5ff;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    background-color: var(--ln-color-primary-soft);
+    box-shadow: var(--ln-shadow-md);
     cursor: pointer;
   }
 
   .page-title-wrapper {
     display: inline-block;
     position: relative;
+  }
+
+  @media (max-width: 768px) {
+    .event-card-section.go-to-event-button button,
+    .event-card-section.other-events-button button {
+      min-height: var(--ln-space-touch);
+    }
   }
 </style>

--- a/website/src/lib/map/EventCard.svelte
+++ b/website/src/lib/map/EventCard.svelte
@@ -54,7 +54,7 @@
       ? $state.snapshot(entry.location)
       : $state.snapshot(entry.locations_latlon[0]);
     const mapTravel =
-      /** @type {((options: { location: any, zoom: number, flyDuration: number }) => void) | null} */ (
+      /** @type {((options: { location: any, zoom: number, flyDuration: number, reserveMobilePane?: boolean }) => void) | null} */ (
         uiGlobals.mapTravel
       );
     if (mapTravel) {
@@ -87,7 +87,7 @@
       ? $state.snapshot(entry.location)
       : $state.snapshot(entry.locations_latlon[0]);
     const mapTravel =
-      /** @type {((options: { location: any, zoom: number, flyDuration: number }) => void) | null} */ (
+      /** @type {((options: { location: any, zoom: number, flyDuration: number, reserveMobilePane?: boolean }) => void) | null} */ (
         uiGlobals.mapTravel
       );
     if (mapTravel) {
@@ -95,6 +95,7 @@
         location: location,
         zoom: appState.zoom,
         flyDuration: 0.3,
+        reserveMobilePane: true,
       });
     }
     setTimeout(() => {

--- a/website/src/lib/map/EventCard.svelte
+++ b/website/src/lib/map/EventCard.svelte
@@ -82,7 +82,9 @@
     }, 310);
   }
 
-  function openSameLocationEvents() {
+  /** @param {MouseEvent} event */
+  function openSameLocationEvents(event) {
+    event.stopPropagation();
     const location = entry.location?.lat
       ? $state.snapshot(entry.location)
       : $state.snapshot(entry.locations_latlon[0]);
@@ -99,15 +101,16 @@
       });
     }
     setTimeout(() => {
-      const update = {
-        paneTab: "same-location-events",
-        wikiPage: "",
-        selectedMarkerId: entry.id,
-      };
-      Object.assign(appState, update);
       Object.assign(uiState, {
         sameLocationEvents: [entry, ...entry.same_location_events],
       });
+      const update = {
+        paneTab: "same-location-events",
+        wikiPage: "",
+        wikiSection: "",
+        selectedMarkerId: null,
+      };
+      Object.assign(appState, update);
     }, 310);
   }
 

--- a/website/src/lib/map/EventCard.svelte
+++ b/website/src/lib/map/EventCard.svelte
@@ -237,7 +237,7 @@
         <img src="{basePath}icons/map.svg" alt="map" />
       </div>
       <div class="event-text">
-        {#each places as place, index}
+        {#each places as place, index (place.name)}
           {#if place.hasPage}
             {#snippet popupContent(isOpen)}
               <WikiPreview pageTitle={place.name} {isOpen} />
@@ -265,7 +265,7 @@
         <img src="{basePath}icons/square-user-round.svg" alt="person" />
       </div>
       <div class="event-text">
-        {#each people as person, index}
+        {#each people as person, index (person.name)}
           {#if person.hasPage}
             {#snippet popupContent(isOpen)}
               <WikiPreview pageTitle={person.name} {isOpen} />

--- a/website/src/lib/map/EventCard.svelte
+++ b/website/src/lib/map/EventCard.svelte
@@ -9,6 +9,15 @@
   } from "../data/date_utils";
   const basePath = import.meta.env.BASE_URL;
 
+  /**
+   * @typedef {Record<string, any>} EventEntry
+   *
+   * @typedef {Object} LinkedItem
+   * @property {string} name
+   * @property {boolean} hasPage
+   */
+
+  /** @type {{ entry: EventEntry, displayPage?: boolean, displayLocation?: boolean, displayGoToEventLink?: boolean, constrainHeight?: boolean, keepPopupsWithinMap?: boolean }} */
   let {
     entry,
     displayPage = true,
@@ -17,7 +26,9 @@
     constrainHeight = false,
     keepPopupsWithinMap = false,
   } = $props();
+  /** @type {LinkedItem[]} */
   let people = $state([]);
+  /** @type {LinkedItem[]} */
   let places = $state([]);
   let fontSize = $state(14);
   onMount(() => {
@@ -42,11 +53,17 @@
     const location = entry.location.lat
       ? $state.snapshot(entry.location)
       : $state.snapshot(entry.locations_latlon[0]);
-    uiGlobals.mapTravel({
-      location: location,
-      zoom: 12,
-      flyDuration: 0.3,
-    });
+    const mapTravel =
+      /** @type {((options: { location: any, zoom: number, flyDuration: number }) => void) | null} */ (
+        uiGlobals.mapTravel
+      );
+    if (mapTravel) {
+      mapTravel({
+        location: location,
+        zoom: 12,
+        flyDuration: 0.3,
+      });
+    }
     if (uiGlobals.isTouchDevice) {
       appState.wikiPage = "";
       appState.wikiSection = "";
@@ -69,11 +86,17 @@
     const location = entry.location?.lat
       ? $state.snapshot(entry.location)
       : $state.snapshot(entry.locations_latlon[0]);
-    uiGlobals.mapTravel({
-      location: location,
-      zoom: appState.zoom,
-      flyDuration: 0.3,
-    });
+    const mapTravel =
+      /** @type {((options: { location: any, zoom: number, flyDuration: number }) => void) | null} */ (
+        uiGlobals.mapTravel
+      );
+    if (mapTravel) {
+      mapTravel({
+        location: location,
+        zoom: appState.zoom,
+        flyDuration: 0.3,
+      });
+    }
     setTimeout(() => {
       const update = {
         paneTab: "same-location-events",
@@ -81,32 +104,48 @@
         selectedMarkerId: entry.id,
       };
       Object.assign(appState, update);
-      uiState.sameLocationEvents = [entry, ...entry.same_location_events];
+      Object.assign(uiState, {
+        sameLocationEvents: [entry, ...entry.same_location_events],
+      });
     }, 310);
   }
 
+  /**
+   * @param {string} pageTitle
+   * @param {string} [pageSection]
+   */
   function openWikiPage(pageTitle, pageSection) {
-    appState.wikiSection = pageSection;
+    appState.wikiSection = /** @type {string} */ (pageSection);
     appState.wikiPage = pageTitle;
     appState.paneTab = "wikipedia";
   }
 
+  /**
+   * @template {Record<string, unknown>} T
+   * @param {T[]} array
+   * @param {keyof T} idKey
+   * @returns {T[]}
+   */
   function deduplicate(array, idKey) {
-    const seen = new Map();
+    /** @type {unknown[]} */
+    const seen = [];
     return array.filter((item) => {
       const value = item[idKey];
-      if (seen.has(value)) {
+      if (seen.includes(value)) {
         return false;
       }
-      seen.set(value, true);
+      seen.push(value);
       return true;
     });
   }
+
+  /** @returns {LinkedItem[]} */
   function parsePeople() {
     if (!entry.people) {
       return [];
     }
-    const peopleList = entry.people
+    /** @type {LinkedItem[]} */
+    const peopleList = /** @type {string} */ (entry.people)
       .split("|")
       .map((person) => {
         const hasPage = !person.trim().endsWith("(?)");
@@ -138,21 +177,29 @@
     return deduplicate(filteredList, "name");
   }
 
+  /** @returns {LinkedItem[]} */
   function parsePlaces() {
     entry.city_page_title = entry.city_page_title || "";
     if (!entry.where_page_title && !entry.city_page_title) {
       return [];
     }
-    const placesWithLinks = [
-      ...entry.where_page_title
+    /** @type {string[]} */
+    const linkedPlaceNames = [
+      .../** @type {string} */ (entry.where_page_title)
         .split("|")
         .filter((place) => place.trim().length > 0),
-      ...entry.city_page_title
+      .../** @type {string} */ (entry.city_page_title)
         .split("|")
         .filter((city) => city.trim().length > 0),
-    ].map((place) => ({ name: place, hasPage: true }));
+    ];
+    /** @type {LinkedItem[]} */
+    const placesWithLinks = [
+      ...linkedPlaceNames.map((place) => ({ name: place, hasPage: true })),
+    ];
 
-    const placeList = (entry.location || "")
+    const locationNames = /** @type {string} */ (entry.location || "");
+    /** @type {LinkedItem[]} */
+    const placeList = locationNames
       .split(/[\|,]/)
       .map((location) => {
         return location
@@ -175,18 +222,11 @@
   }
 </script>
 
-{#snippet linkedPage(pageTitle, pageSection)}
-  <span
-    class="wiki-link"
-    onclick={() => openWikiPage(pageTitle, pageSection)}
-    role="button"
-    tabindex="0"
-    onkeydown={(e) => {
-      if (e.key === "Enter") {
-        openWikiPage(pageTitle, pageSection);
-      }
-    }}
-  >
+{#snippet linkedPage(
+  /** @type {string} */ pageTitle,
+  /** @type {string | undefined} */ pageSection = undefined
+)}
+  <span class="wiki-link">
     {pageTitle}
   </span>
 {/snippet}
@@ -203,12 +243,16 @@
         <img src="{basePath}icons/text-search.svg" alt="search" />
       </div>
       <div class="event-text">
-        {#snippet popupContent(isOpen)}
+        {#snippet popupContent(/** @type {boolean} */ isOpen)}
           <WikiPreview pageTitle={entry.pageTitle} {isOpen} />
         {/snippet}
         <span class="page-title-wrapper">
           <MapPopup
             {popupContent}
+            popupLabel={`Wikipedia preview for ${entry.pageTitle}`}
+            triggerLabel={`Open Wikipedia page for ${entry.pageTitle}`}
+            onTriggerActivate={() =>
+              openWikiPage(entry.pageTitle, entry.page_section)}
             enterable={false}
             keepWithinMap={keepPopupsWithinMap}
           >
@@ -239,11 +283,14 @@
       <div class="event-text">
         {#each places as place, index (place.name)}
           {#if place.hasPage}
-            {#snippet popupContent(isOpen)}
+            {#snippet popupContent(/** @type {boolean} */ isOpen)}
               <WikiPreview pageTitle={place.name} {isOpen} />
             {/snippet}
             <MapPopup
               {popupContent}
+              popupLabel={`Wikipedia preview for ${place.name}`}
+              triggerLabel={`Open Wikipedia page for ${place.name}`}
+              onTriggerActivate={() => openWikiPage(place.name)}
               enterable={false}
               keepWithinMap={keepPopupsWithinMap}
             >
@@ -267,11 +314,14 @@
       <div class="event-text">
         {#each people as person, index (person.name)}
           {#if person.hasPage}
-            {#snippet popupContent(isOpen)}
+            {#snippet popupContent(/** @type {boolean} */ isOpen)}
               <WikiPreview pageTitle={person.name} {isOpen} />
             {/snippet}
             <MapPopup
               {popupContent}
+              popupLabel={`Wikipedia preview for ${person.name}`}
+              triggerLabel={`Open Wikipedia page for ${person.name}`}
+              onTriggerActivate={() => openWikiPage(person.name)}
               enterable={false}
               keepWithinMap={keepPopupsWithinMap}
             >
@@ -291,7 +341,7 @@
     <div class="event-icon">
       <img src="{basePath}icons/newspaper.svg" alt="newspaper" />
     </div>
-    {#snippet popupContent(isOpen)}
+    {#snippet popupContent(/** @type {boolean} */ isOpen)}
       <WikiPreview pageTitle={entry.pageTitle} {isOpen} />
     {/snippet}
     <div class="event-text">

--- a/website/src/lib/map/MapPopup.svelte
+++ b/website/src/lib/map/MapPopup.svelte
@@ -4,10 +4,21 @@
   import { onMount } from "svelte";
   import { portal } from "svelte-portal";
 
+  const generatedPopupId = $props.id();
+
   // Add portal target check
+  /** @type {HTMLElement | null} */
   let portalTarget = $state(null);
 
   let {
+    popupId = generatedPopupId,
+    popupLabel = "Map popup",
+    popupLabelledby = undefined,
+    triggerLabel = undefined,
+    triggerTitle = undefined,
+    triggerRole = "button",
+    triggerTag = "span",
+    onTriggerActivate = undefined,
     popupContent,
     children,
     alwaysOpen = false,
@@ -15,19 +26,25 @@
     visibilityDelay = 0,
     keepWithinMap = false,
   } = $props(); // Title to look up
+  /** @type {HTMLElement | null} */
   let popupElement = $state(null); // Reference to popup element
-  let triggerElement = $state(null); // Reference to trigger span
+  /** @type {HTMLElement | null} */
+  let triggerElement = $state(null); // Reference to trigger element
   let popupTop = $state(0);
   let popupLeft = $state(0);
   let isHovered = $state(false);
   let isOpen = $derived(alwaysOpen || (!uiGlobals.isTouchDevice && isHovered));
-  let closeTimeout = $state(null);
-  let visibilityTimeout = $state(null); // Track visibility timeout
+  let popupAriaLabel = $derived(popupLabelledby ? undefined : popupLabel);
+  /** @type {number | undefined} */
+  let closeTimeout = $state(undefined);
+  /** @type {number | undefined} */
+  let visibilityTimeout = $state(undefined); // Track visibility timeout
   let visibility = $state("hidden");
   let zIndex = $state(8000);
   let popupStyle = $derived(
     `transform: translate(${popupLeft}px, ${popupTop}px); visibility: ${visibility}; z-index: ${zIndex};`
   );
+  /** @type {ResizeObserver | null} */
   let resizeObserver = $state(null);
 
   onMount(() => {
@@ -39,7 +56,7 @@
 
     if (popupElement) {
       // Find parent popup if it exists
-      let parent = triggerElement.closest(".map-popup");
+      let parent = triggerElement?.closest(".map-popup");
       if (parent) {
         // Get parent's z-index and increment by 10
         const parentZIndex =
@@ -194,6 +211,7 @@
   }
 
   // Helper function to find the nearest scrollable parent
+  /** @param {HTMLElement | null} element */
   function findScrollableParent(element) {
     if (!element) return document.documentElement;
 
@@ -221,15 +239,7 @@
         isHovered = false;
       }, 200);
     } else {
-      // For non-enterable popups, immediately close
-      isHovered = false;
-      // Clear any pending visibility timeout
-      clearTimeout(visibilityTimeout);
-      // Force immediate visibility hiding
-      visibility = "hidden";
-      if (popupElement) {
-        popupElement.style.visibility = "hidden";
-      }
+      closeHoverPopup();
     }
   }
   function clearCloseTimeoutIfEnterable() {
@@ -241,10 +251,63 @@
     clearCloseTimeoutIfEnterable();
     isHovered = true;
   }
+
+  function closeHoverPopup({ focusTrigger = false } = {}) {
+    isHovered = false;
+    clearTimeout(closeTimeout);
+    clearTimeout(visibilityTimeout);
+    visibility = "hidden";
+    if (popupElement) {
+      popupElement.style.visibility = "hidden";
+    }
+    if (focusTrigger && triggerElement) {
+      triggerElement.focus();
+    }
+  }
+
+  /** @param {KeyboardEvent} event */
+  function handleEscape(event) {
+    if (event.key !== "Escape" || !isOpen || alwaysOpen) {
+      return;
+    }
+
+    const activeElement = document.activeElement;
+    const focusInPopup = popupElement?.contains(activeElement);
+    const focusInTrigger = triggerElement?.contains(activeElement);
+
+    if (focusInPopup || focusInTrigger || isHovered) {
+      event.stopPropagation();
+      closeHoverPopup({ focusTrigger: focusInPopup });
+    }
+  }
+
+  /** @param {MouseEvent} event */
+  function handleTriggerClick(event) {
+    onTriggerActivate?.(event);
+  }
+
+  /** @param {KeyboardEvent} event */
+  function handleTriggerKeydown(event) {
+    if (event.key === "Escape") {
+      handleEscape(event);
+      return;
+    }
+
+    if (
+      (event.key === "Enter" || event.key === " ") &&
+      typeof onTriggerActivate === "function"
+    ) {
+      event.preventDefault();
+      onTriggerActivate(event);
+    }
+  }
 </script>
+
+<svelte:window onkeydown={handleEscape} />
 
 {#if portalTarget}
   <div
+    id={popupId}
     class="map-popup"
     use:portal={"#main"}
     bind:this={popupElement}
@@ -255,13 +318,20 @@
       }
     }}
     onmouseleave={onMouseLeave}
+    onfocusin={clearCloseTimeoutIfEnterable}
+    onfocusout={onMouseLeave}
     tabindex="-1"
-    role="tooltip"
+    role="dialog"
+    aria-modal="false"
+    aria-label={popupAriaLabel}
+    aria-labelledby={popupLabelledby}
+    aria-hidden={!isOpen}
   >
     {@render popupContent(isOpen)}
   </div>
 {:else}
   <div
+    id={popupId}
     class="map-popup"
     bind:this={popupElement}
     style={popupStyle}
@@ -271,24 +341,38 @@
       }
     }}
     onmouseleave={onMouseLeave}
+    onfocusin={clearCloseTimeoutIfEnterable}
+    onfocusout={onMouseLeave}
     tabindex="-1"
-    role="tooltip"
+    role="dialog"
+    aria-modal="false"
+    aria-label={popupAriaLabel}
+    aria-labelledby={popupLabelledby}
+    aria-hidden={!isOpen}
   >
     {@render popupContent(isOpen)}
   </div>
 {/if}
 
-<span
+<svelte:element
+  this={triggerTag}
   bind:this={triggerElement}
-  role="button"
-  tabindex="0"
+  role={triggerRole}
+  tabindex={triggerRole ? 0 : undefined}
+  aria-haspopup={triggerRole ? "dialog" : undefined}
+  aria-expanded={triggerRole ? isOpen : undefined}
+  aria-controls={triggerRole ? popupId : undefined}
+  aria-label={triggerLabel}
+  title={triggerTitle}
   onmouseenter={onMouseEnter}
   onmouseleave={onMouseLeave}
-  onfocus={onMouseEnter}
-  onblur={onMouseLeave}
+  onfocusin={onMouseEnter}
+  onfocusout={onMouseLeave}
+  onclick={handleTriggerClick}
+  onkeydown={handleTriggerKeydown}
 >
   {@render children()}
-</span>
+</svelte:element>
 
 <style>
   :global(.map-popup) {

--- a/website/src/lib/map/MapPopup.svelte
+++ b/website/src/lib/map/MapPopup.svelte
@@ -418,10 +418,10 @@
     overflow: visible;
     padding: 0;
 
-    background: #fff;
-    border: 1px solid #a2a9b1;
-    border-radius: 2px;
-    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15);
+    background: var(--ln-color-surface);
+    border: 1px solid var(--ln-color-border);
+    border-radius: var(--ln-radius-lg);
+    box-shadow: var(--ln-shadow-popup);
     transition: opacity 0.2s ease-out;
     font-size: 14px;
   }

--- a/website/src/lib/map/MapPopup.svelte
+++ b/website/src/lib/map/MapPopup.svelte
@@ -18,6 +18,7 @@
     triggerTitle = undefined,
     triggerRole = "button",
     triggerTag = "span",
+    triggerClass = undefined,
     onTriggerActivate = undefined,
     popupContent,
     children,
@@ -35,6 +36,13 @@
   let isHovered = $state(false);
   let isOpen = $derived(alwaysOpen || (!uiGlobals.isTouchDevice && isHovered));
   let popupAriaLabel = $derived(popupLabelledby ? undefined : popupLabel);
+  let isNativeButtonTrigger = $derived(triggerTag === "button");
+  let effectiveTriggerRole = $derived(
+    isNativeButtonTrigger ? undefined : triggerRole
+  );
+  let triggerHasPopupSemantics = $derived(
+    isNativeButtonTrigger || Boolean(effectiveTriggerRole)
+  );
   /** @type {number | undefined} */
   let closeTimeout = $state(undefined);
   /** @type {number | undefined} */
@@ -293,6 +301,10 @@
       return;
     }
 
+    if (isNativeButtonTrigger) {
+      return;
+    }
+
     if (
       (event.key === "Enter" || event.key === " ") &&
       typeof onTriggerActivate === "function"
@@ -354,25 +366,49 @@
   </div>
 {/if}
 
-<svelte:element
-  this={triggerTag}
-  bind:this={triggerElement}
-  role={triggerRole}
-  tabindex={triggerRole ? 0 : undefined}
-  aria-haspopup={triggerRole ? "dialog" : undefined}
-  aria-expanded={triggerRole ? isOpen : undefined}
-  aria-controls={triggerRole ? popupId : undefined}
-  aria-label={triggerLabel}
-  title={triggerTitle}
-  onmouseenter={onMouseEnter}
-  onmouseleave={onMouseLeave}
-  onfocusin={onMouseEnter}
-  onfocusout={onMouseLeave}
-  onclick={handleTriggerClick}
-  onkeydown={handleTriggerKeydown}
->
-  {@render children()}
-</svelte:element>
+{#if isNativeButtonTrigger}
+  <button
+    bind:this={triggerElement}
+    class={triggerClass}
+    type="button"
+    aria-haspopup="dialog"
+    aria-expanded={isOpen}
+    aria-controls={popupId}
+    aria-describedby={isOpen ? popupId : undefined}
+    aria-label={triggerLabel}
+    title={triggerTitle}
+    onmouseenter={onMouseEnter}
+    onmouseleave={onMouseLeave}
+    onfocusin={onMouseEnter}
+    onfocusout={onMouseLeave}
+    onclick={handleTriggerClick}
+    onkeydown={handleTriggerKeydown}
+  >
+    {@render children()}
+  </button>
+{:else}
+  <svelte:element
+    this={triggerTag}
+    bind:this={triggerElement}
+    class={triggerClass}
+    role={effectiveTriggerRole}
+    tabindex={effectiveTriggerRole ? 0 : undefined}
+    aria-haspopup={triggerHasPopupSemantics ? "dialog" : undefined}
+    aria-expanded={triggerHasPopupSemantics ? isOpen : undefined}
+    aria-controls={triggerHasPopupSemantics ? popupId : undefined}
+    aria-describedby={triggerHasPopupSemantics && isOpen ? popupId : undefined}
+    aria-label={triggerLabel}
+    title={triggerTitle}
+    onmouseenter={onMouseEnter}
+    onmouseleave={onMouseLeave}
+    onfocusin={onMouseEnter}
+    onfocusout={onMouseLeave}
+    onclick={handleTriggerClick}
+    onkeydown={handleTriggerKeydown}
+  >
+    {@render children()}
+  </svelte:element>
+{/if}
 
 <style>
   :global(.map-popup) {

--- a/website/src/lib/map/MarkerIcon.svelte
+++ b/website/src/lib/map/MarkerIcon.svelte
@@ -3,6 +3,18 @@
   import EventCard from "./EventCard.svelte";
   import WikiPreview from "./WikiPreview.svelte";
   import { appState, uiGlobals } from "../appState.svelte.js";
+
+  /**
+   * @typedef {Object} MarkerEntry
+   * @property {string} category
+   * @property {string} displayClass
+   * @property {boolean} isEvent
+   * @property {string} name
+   * @property {string} pageTitle
+   * @property {unknown[]} [same_location_events]
+   */
+
+  /** @type {{ entry: MarkerEntry, onClick?: ((event: MouseEvent | KeyboardEvent) => void) | null }} */
   const { entry, onClick = null } = $props();
 
   const basePath = import.meta.env.BASE_URL;
@@ -43,6 +55,7 @@
     work: "briefcase-business",
     travel: "luggage",
   };
+  /** @type {Record<string, string>} */
   const iconByType = {
     ...iconByPlaceType,
     ...iconsByEventType,
@@ -64,23 +77,14 @@
     `Show ${entry.name}${entry.name !== entry.pageTitle ? ` from ${entry.pageTitle}` : ""}`
   );
 
+  /** @param {string} pageTitle */
   function openWikiPage(pageTitle) {
     appState.wikiPage = pageTitle;
     appState.paneTab = "wikipedia";
   }
-
-  /** @param {KeyboardEvent} event */
-  function handleKeydown(event) {
-    if (event.key !== "Enter" && event.key !== " ") {
-      return;
-    }
-
-    event.preventDefault();
-    onClick?.(event);
-  }
 </script>
 
-{#snippet popupContent(isOpen)}
+{#snippet popupContent(/** @type {boolean} */ isOpen)}
   {#if entry.isEvent}
     <EventCard {entry} constrainHeight={true} keepPopupsWithinMap={true} />
   {:else}
@@ -90,6 +94,13 @@
 
 <MapPopup
   {popupContent}
+  popupLabel={entry.isEvent
+    ? `Event details for ${entry.name}`
+    : `Wikipedia preview for ${entry.pageTitle}`}
+  triggerLabel={markerTitle}
+  triggerTitle={markerTitle}
+  triggerTag="div"
+  onTriggerActivate={onClick}
   enterable={entry.isEvent || uiGlobals.isTouchDevice}
   alwaysOpen={uiGlobals.isTouchDevice && entry.displayClass === "selected"}
   visibilityDelay={entry.isEvent ? 0 : 100}
@@ -97,12 +108,6 @@
 >
   <div
     class={`map-marker marker-display-${entry.displayClass}`}
-    onclick={onClick}
-    onkeydown={handleKeydown}
-    role="button"
-    tabindex="0"
-    aria-label={markerTitle}
-    title={markerTitle}
   >
     <div class="marker-icon-circle">
       <img src={basePath + "icons/" + iconName + ".svg"} alt="icon" />
@@ -228,7 +233,6 @@
       font-weight: bold;
       color: white;
       -webkit-text-stroke: 4px white;
-      text-stroke: 4px white;
       z-index: 1;
     }
   }
@@ -247,9 +251,7 @@
     font-weight: bold;
     color: white;
     -webkit-text-stroke: 6px white;
-    text-stroke: 6px white;
     -webkit-text-stroke-linejoin: round;
-    text-stroke-linejoin: round;
     z-index: 1;
   }
 

--- a/website/src/lib/map/MarkerIcon.svelte
+++ b/website/src/lib/map/MarkerIcon.svelte
@@ -162,7 +162,7 @@
     &:hover > .marker-icon-circle,
     &.marker-display-selected > .marker-icon-circle {
       --circle-size: 32px !important;
-      box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.35);
+      box-shadow: var(--ln-shadow-marker);
       z-index: 900 !important;
     }
 
@@ -183,8 +183,8 @@
     }
 
     &.marker-display-selected > .marker-icon-circle {
-      border: 6px solid #f00707;
-      box-shadow: 8px 8px 16px rgba(0, 0, 0, 0.95);
+      border: 4px solid var(--ln-color-marker-selected);
+      box-shadow: var(--ln-shadow-marker-selected);
     }
 
     &.marker-display-full > .marker-text-container {
@@ -194,7 +194,7 @@
 
     &.marker-display-full > .marker-icon-circle {
       --circle-size: 32px;
-      box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.35);
+      box-shadow: var(--ln-shadow-marker);
     }
 
     &.marker-display-reduced > .marker-icon-circle {
@@ -212,9 +212,9 @@
     & > .marker-icon-circle {
       width: var(--circle-size);
       height: var(--circle-size);
-      background-color: white;
+      background-color: var(--ln-color-surface);
       border-radius: 50%;
-      border: 2px solid #222;
+      border: 2px solid var(--ln-color-marker-stroke);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -235,6 +235,11 @@
     }
   }
 
+  :global(.map-marker-trigger:focus-visible) .marker-icon-circle {
+    outline: 3px solid var(--ln-color-focus);
+    outline-offset: 2px;
+  }
+
   .marker-text-container {
     margin-top: -5px;
     font-size: 14px;
@@ -252,15 +257,15 @@
       left: 0;
       right: 0;
       font-weight: bold;
-      color: white;
-      -webkit-text-stroke: 4px white;
+      color: var(--ln-color-surface);
+      -webkit-text-stroke: 4px var(--ln-color-surface);
       z-index: 1;
     }
   }
 
   .marker-text {
     font-weight: bold;
-    color: #111;
+    color: var(--ln-color-text);
     position: relative;
     z-index: 2;
   }
@@ -270,8 +275,8 @@
     left: 0;
     right: 0;
     font-weight: bold;
-    color: white;
-    -webkit-text-stroke: 6px white;
+    color: var(--ln-color-surface);
+    -webkit-text-stroke: 6px var(--ln-color-surface);
     -webkit-text-stroke-linejoin: round;
     z-index: 1;
   }
@@ -280,9 +285,9 @@
     position: absolute;
     top: -8px;
     right: -8px;
-    background-color: #ff5a5f;
-    color: white;
-    border-radius: 30%;
+    background-color: var(--ln-color-event-count);
+    color: var(--ln-color-surface);
+    border-radius: var(--ln-radius-pill);
     font-size: 10px;
     font-weight: bold;
     min-width: 14px;
@@ -290,9 +295,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 2px solid white;
+    border: 2px solid var(--ln-color-surface);
     padding: 0 2px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--ln-shadow-sm);
     z-index: 5;
   }
 </style>

--- a/website/src/lib/map/MarkerIcon.svelte
+++ b/website/src/lib/map/MarkerIcon.svelte
@@ -51,7 +51,7 @@
   const iconName = $derived(iconByType[entry.category] || iconByType.other);
 
   // Compute the label based on entry name and page title
-  const label = $derived(() => {
+  const label = $derived.by(() => {
     if (entry.name !== entry.pageTitle) {
       const fullLabel = entry.name + " - " + entry.pageTitle;
       if (fullLabel.length <= 30) {
@@ -60,10 +60,23 @@
     }
     return entry.name;
   });
+  const markerTitle = $derived(
+    `Show ${entry.name}${entry.name !== entry.pageTitle ? ` from ${entry.pageTitle}` : ""}`
+  );
 
   function openWikiPage(pageTitle) {
     appState.wikiPage = pageTitle;
     appState.paneTab = "wikipedia";
+  }
+
+  /** @param {KeyboardEvent} event */
+  function handleKeydown(event) {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+
+    event.preventDefault();
+    onClick?.(event);
   }
 </script>
 
@@ -85,9 +98,11 @@
   <div
     class={`map-marker marker-display-${entry.displayClass}`}
     onclick={onClick}
-    onkeydown={onClick}
+    onkeydown={handleKeydown}
     role="button"
     tabindex="0"
+    aria-label={markerTitle}
+    title={markerTitle}
   >
     <div class="marker-icon-circle">
       <img src={basePath + "icons/" + iconName + ".svg"} alt="icon" />
@@ -99,8 +114,8 @@
     </div>
 
     <div class="marker-text-container">
-      <div class="marker-text marker-text-outline">{label()}</div>
-      <div class="marker-text">{label()}</div>
+      <div class="marker-text marker-text-outline">{label}</div>
+      <div class="marker-text">{label}</div>
     </div>
   </div>
 </MapPopup>

--- a/website/src/lib/map/MarkerIcon.svelte
+++ b/website/src/lib/map/MarkerIcon.svelte
@@ -108,9 +108,10 @@
 >
   <div
     class={`map-marker marker-display-${entry.displayClass}`}
+    aria-hidden="true"
   >
     <div class="marker-icon-circle">
-      <img src={basePath + "icons/" + iconName + ".svg"} alt="icon" />
+      <img src={basePath + "icons/" + iconName + ".svg"} alt="" />
       {#if entry.isEvent && entry.same_location_events && entry.same_location_events.length > 0}
         <div class="event-count-indicator">
           +{entry.same_location_events.length}

--- a/website/src/lib/map/MarkerIcon.svelte
+++ b/website/src/lib/map/MarkerIcon.svelte
@@ -99,7 +99,8 @@
     : `Wikipedia preview for ${entry.pageTitle}`}
   triggerLabel={markerTitle}
   triggerTitle={markerTitle}
-  triggerTag="div"
+  triggerTag="button"
+  triggerClass="map-marker-trigger"
   onTriggerActivate={onClick}
   enterable={entry.isEvent || uiGlobals.isTouchDevice}
   alwaysOpen={uiGlobals.isTouchDevice && entry.displayClass === "selected"}
@@ -127,6 +128,25 @@
 </MapPopup>
 
 <style>
+  :global(.map-marker-trigger) {
+    appearance: none;
+    -webkit-appearance: none;
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    line-height: 0;
+    cursor: pointer;
+    overflow: visible;
+  }
+
   .map-marker {
     transition:
       transform 0.1s ease,

--- a/website/src/lib/map/WikiPreview.svelte
+++ b/website/src/lib/map/WikiPreview.svelte
@@ -1,3 +1,17 @@
+<script module>
+  /**
+   * @typedef {Object} WikiPreview
+   * @property {string} summary
+   * @property {string} thumbnail
+   * @property {number} imageWidth
+   * @property {number} imageHeight
+   * @property {boolean} imageHasWhiteBackground
+   */
+
+  /** @type {Record<string, WikiPreview>} */
+  const wikiPreviewCache = Object.create(null);
+</script>
+
 <script>
   // Reactive state
   import { uiGlobals, appState } from "../appState.svelte";
@@ -8,31 +22,69 @@
   let imageWidth = $state(120);
   let imageHasWhiteBackground = $state(false);
   let infosFetched = $state(false);
-  let fontSize = $state("1rem"); // New state for dynamic font size
+  let requestedTitle = "";
+  let loadedTitle = "";
+  let fontSize = $derived(
+    summary ? (summary.length > 250 ? "12px" : "14px") : "1rem",
+  ); // New state for dynamic font size
 
   $effect(() => {
-    if (isOpen && !infosFetched) {
-      fetchWikiInfos();
+    if (!isOpen || !pageTitle) {
+      return;
+    }
+
+    if (loadedTitle === pageTitle && infosFetched) {
+      return;
+    }
+
+    if (requestedTitle !== pageTitle) {
+      resetPreview();
+      requestedTitle = pageTitle;
+      fetchWikiInfos(pageTitle);
     }
   });
 
-  // New effect to update font size based on content
-  $effect(() => {
-    if (summary) {
-      const baseSize = 0.9;
-      const shouldReduce = summary.length > 250;
-      fontSize = `${shouldReduce ? "12px" : "14px"}`; // 0.0625rem = 1px
-    }
-  });
+  function resetPreview() {
+    summary = "";
+    thumbnail = "";
+    imageWidth = 120;
+    imageHeight = 140;
+    imageHasWhiteBackground = false;
+    infosFetched = false;
+    loadedTitle = "";
+  }
+
+  /**
+   * @param {WikiPreview} preview
+   * @param {string} title
+   */
+  function applyPreview(preview, title) {
+    summary = preview.summary;
+    thumbnail = preview.thumbnail;
+    imageWidth = preview.imageWidth;
+    imageHeight = preview.imageHeight;
+    imageHasWhiteBackground = preview.imageHasWhiteBackground;
+    loadedTitle = title;
+    infosFetched = true;
+  }
 
   /**
    * Fetches summary and thumbnail information from Wikipedia API for the given page title.
    * Updates the component state with extracted summary and image properties.
+   * @param {string} title
    * @returns {Promise<void>}
    */
-  async function fetchWikiInfos() {
+  async function fetchWikiInfos(title) {
+    const cachedPreview = wikiPreviewCache[title];
+    if (cachedPreview) {
+      if (requestedTitle === title && pageTitle === title) {
+        applyPreview(cachedPreview, title);
+      }
+      return;
+    }
+
     const wikiEndpoint = "https://en.wikipedia.org/api/rest_v1/page/summary/";
-    const encodedTitle = encodeURIComponent(pageTitle.replaceAll(" ", "_"));
+    const encodedTitle = encodeURIComponent(title.replaceAll(" ", "_"));
 
     let url;
     let requestOptions;
@@ -48,30 +100,42 @@
     }
 
     const res = await fetch(url, requestOptions);
+    /** @type {WikiPreview} */
+    const preview = {
+      summary: "",
+      thumbnail: "",
+      imageWidth: 120,
+      imageHeight: 140,
+      imageHasWhiteBackground: false,
+    };
+
     if (res.ok) {
       const data = await res.json();
-      summary = extractSummary(data.extract_html);
+      preview.summary = extractSummary(data.extract_html);
 
-      thumbnail = data.thumbnail?.source || "";
+      preview.thumbnail = data.thumbnail?.source || "";
       // Calculate dimensions that maintain aspect ratio within our constraints
       if (data.thumbnail) {
-        ({ imageWidth, imageHeight } = calculateDimensions(data.thumbnail));
-        imageHasWhiteBackground =
-          await checkImageCornersForWhiteBackground(thumbnail);
+        const dimensions = calculateDimensions(data.thumbnail);
+        preview.imageWidth = dimensions.imageWidth;
+        preview.imageHeight = dimensions.imageHeight;
+        preview.imageHasWhiteBackground =
+          await checkImageCornersForWhiteBackground(preview.thumbnail);
       }
     } else {
-      summary = "No information available.";
-      thumbnail = "";
+      preview.summary = "No information available.";
     }
-    infosFetched = true;
+
+    wikiPreviewCache[title] = preview;
+    if (requestedTitle === title && pageTitle === title) {
+      applyPreview(preview, title);
+    }
   }
 
   /**
    * Calculates optimal dimensions for the thumbnail while maintaining aspect ratio.
-   * @param {Object} thumbnail - The thumbnail object from Wikipedia API
-   * @param {number} thumbnail.width - Original width of the thumbnail
-   * @param {number} thumbnail.height - Original height of the thumbnail
-   * @returns {Object} Object containing calculated imageWidth and imageHeight
+   * @param {{ width: number, height: number }} thumbnail - The thumbnail object from Wikipedia API
+   * @returns {{ imageWidth: number, imageHeight: number }} Object containing calculated imageWidth and imageHeight
    */
   function calculateDimensions(thumbnail) {
     const maxWidth = 120;
@@ -151,6 +215,10 @@
         canvas.width = img.width;
         canvas.height = img.height;
         const ctx = canvas.getContext("2d", { willReadFrequently: true });
+        if (!ctx) {
+          resolve(false);
+          return;
+        }
         ctx.drawImage(img, 0, 0);
 
         const positions = [

--- a/website/src/lib/map/WikiPreview.svelte
+++ b/website/src/lib/map/WikiPreview.svelte
@@ -303,6 +303,7 @@
     padding: 12px 12px;
     position: relative;
     overflow-y: hidden !important;
+    color: var(--ln-color-text);
   }
 
   .wiki-content::after {
@@ -315,7 +316,7 @@
     background: linear-gradient(
       to bottom,
       rgba(255, 255, 255, 0),
-      rgba(255, 255, 255, 1)
+      var(--ln-color-surface)
     );
     pointer-events: none;
   }
@@ -325,7 +326,7 @@
     font-size: 1.2rem;
     font-weight: normal;
     margin: 0 0 -0.5em;
-    color: #222;
+    color: var(--ln-color-text);
     border-bottom: none;
   }
 
@@ -333,12 +334,10 @@
     margin-bottom: 0.2rem;
     float: right;
     margin-left: 1rem;
-    border-radius: 2px;
+    border-radius: var(--ln-radius-sm);
 
     &.with-shadow {
-      box-shadow:
-        0 2px 4px rgba(0, 0, 0, 0.15),
-        0 0 2px rgba(0, 0, 0, 0.1);
+      box-shadow: var(--ln-shadow-md);
     }
   }
 
@@ -354,17 +353,18 @@
     cursor: pointer;
     display: block;
     padding: 0.5em 1em;
-    background-color: white;
-    color: #0645ad;
+    min-height: var(--ln-space-touch);
+    background-color: var(--ln-color-surface);
+    color: var(--ln-color-primary);
     text-decoration: none;
     font-weight: 600;
-    border: 1px solid #0645ad;
-    border-radius: 4px;
+    border: 1px solid var(--ln-color-primary);
+    border-radius: var(--ln-radius-lg);
     margin: 0.2em auto 0.2em;
     transition:
-      background-color 0.2s,
+      background-color var(--ln-transition-base),
       transform 0.1s;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--ln-shadow-sm);
     position: absolute;
     bottom: 5px;
     left: 50%;
@@ -377,8 +377,8 @@
     width: 24px;
     height: 24px;
     margin: 20px auto;
-    border: 3px solid #f3f3f3;
-    border-top: 3px solid #0645ad;
+    border: 3px solid var(--ln-color-border-muted);
+    border-top: 3px solid var(--ln-color-primary);
     border-radius: 50%;
     animation: spin 1s linear infinite;
   }

--- a/website/src/lib/map/WorldMap.svelte
+++ b/website/src/lib/map/WorldMap.svelte
@@ -135,7 +135,12 @@
   }
 
   // ===== MAP CONTROL FUNCTIONS =====
-  export function mapTravel({ location, zoom, flyDuration }) {
+  export function mapTravel({
+    location,
+    zoom,
+    flyDuration,
+    reserveMobilePane = false,
+  }) {
     const { lat, lon } = location;
     clearTimeout(handleBoundChangesAfterFlyToTimeOut);
     clearTimeout(fixZoomAfterFlyToTimeOut);
@@ -146,14 +151,21 @@
       markerLayer.clearLayers();
     }
 
+    const travelCenter = getTravelCenter({
+      lat,
+      lon,
+      zoom,
+      reserveMobilePane,
+    });
+
     if (flyDuration == 0) {
-      map.setView([lat, lon], zoom, {
+      map.setView(travelCenter, zoom, {
         animate: false,
         duration: 0,
       });
     } else {
       isFlying = true;
-      map.flyTo([lat, lon], zoom, {
+      map.flyTo(travelCenter, zoom, {
         animate: true,
         duration: flyDuration, // Duration in seconds
       });
@@ -177,6 +189,31 @@
     }
   }
   uiGlobals.mapTravel = mapTravel;
+
+  function getTravelCenter({ lat, lon, zoom, reserveMobilePane }) {
+    const bottomInset = getMobilePaneBottomInset({ reserveMobilePane });
+    if (!bottomInset) {
+      return [lat, lon];
+    }
+
+    const targetPoint = map.project([lat, lon], zoom);
+    const adjustedCenterPoint = targetPoint.add([0, bottomInset / 2]);
+    const adjustedCenter = map.unproject(adjustedCenterPoint, zoom);
+    return [adjustedCenter.lat, adjustedCenter.lng];
+  }
+
+  function getMobilePaneBottomInset({ reserveMobilePane }) {
+    const paneIsOpen =
+      appState.wikiPage ||
+      appState.paneTab === "same-location-events" ||
+      appState.paneTab === "about";
+
+    if ((!paneIsOpen && !reserveMobilePane) || window.innerWidth > 768) {
+      return 0;
+    }
+
+    return window.innerHeight * 0.5;
+  }
 
   // ===== EVENT HANDLERS =====
   function handleBoundsChange() {

--- a/website/src/lib/map/WorldMap.svelte
+++ b/website/src/lib/map/WorldMap.svelte
@@ -308,6 +308,11 @@
 
     const newDotMarkerLayer = L.layerGroup();
     const newDotMarkers = new Map();
+    const dotStroke = cssToken(
+      map.getZoom() < 7 ? "--ln-color-text-subtle" : "--ln-color-text",
+      map.getZoom() < 7 ? "#777" : "#111"
+    );
+    const dotFill = cssToken("--ln-color-surface", "white");
 
     for (const dotEntry of mapEntries.dots) {
       const markerId = dotEntry.id || `${dotEntry.lat}-${dotEntry.lon}`;
@@ -323,8 +328,8 @@
         marker = L.circleMarker([dotEntry.lat, dotEntry.lon], {
           radius: 4,
           weight: 1,
-          color: map.getZoom() < 7 ? "#777" : "#111",
-          fillColor: "white",
+          color: dotStroke,
+          fillColor: dotFill,
           fillOpacity: 1,
           pane: "dots",
         });
@@ -343,6 +348,12 @@
     newDotMarkerLayer.addTo(map);
     dotMarkerLayer = newDotMarkerLayer;
     currentDotMarkers = newDotMarkers;
+  }
+
+  function cssToken(name, fallback) {
+    return getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim() || fallback;
   }
 </script>
 
@@ -365,7 +376,7 @@
   }
 
   :global(.leaflet-popup-tip) {
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: var(--ln-color-surface);
   }
 
   /* :global(.leaflet-popup-pane) {

--- a/website/src/lib/map/WorldMap.svelte
+++ b/website/src/lib/map/WorldMap.svelte
@@ -97,7 +97,7 @@
       // "https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg",
       {
         attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
         maxZoom: 19,
         minZoom: 2,
       }

--- a/website/src/lib/map/WorldMap.svelte
+++ b/website/src/lib/map/WorldMap.svelte
@@ -332,7 +332,9 @@
           fillColor: dotFill,
           fillOpacity: 1,
           pane: "dots",
+          bubblingMouseEvents: false,
         });
+        marker.on("click", () => handleDotClick(dotEntry));
       }
       marker.addTo(newDotMarkerLayer);
       newDotMarkers.set(markerId, {
@@ -348,6 +350,17 @@
     newDotMarkerLayer.addTo(map);
     dotMarkerLayer = newDotMarkerLayer;
     currentDotMarkers = newDotMarkers;
+  }
+
+  function handleDotClick(dotEntry) {
+    if (!map) return;
+    const maxZoom = map.getMaxZoom();
+    const targetZoom = Math.min(map.getZoom() + 2, maxZoom);
+    mapTravel({
+      location: { lat: dotEntry.lat, lon: dotEntry.lon },
+      zoom: targetZoom,
+      flyDuration: 0.5,
+    });
   }
 
   function cssToken(name, fallback) {

--- a/website/src/lib/map/createMarker.js
+++ b/website/src/lib/map/createMarker.js
@@ -30,6 +30,7 @@ export function createMarker({ entry }) {
   const marker = L.marker([entry.lat, entry.lon], {
     icon: divIcon,
     pane: entry.displayClass + "MarkersPane",
+    keyboard: false,
   });
 
   // Store the current display class on the marker

--- a/website/src/lib/map/createMarker.js
+++ b/website/src/lib/map/createMarker.js
@@ -184,5 +184,6 @@ function selectMarkerAndCenterOnIt({ entry, selectDelay = 0 }) {
   uiGlobals.mapTravel({
     location: { lat: entry.lat, lon: entry.lon },
     flyDuration: 0.3,
+    reserveMobilePane: true,
   });
 }

--- a/website/src/lib/menu/DatePicker.svelte
+++ b/website/src/lib/menu/DatePicker.svelte
@@ -207,18 +207,18 @@
   .date-input {
     box-sizing: border-box;
     padding: 8px 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    background-color: #ffffff;
-    color: #374151;
+    border: 1px solid var(--ln-color-border);
+    border-radius: var(--ln-radius-lg);
+    background-color: var(--ln-color-surface);
+    color: var(--ln-color-text);
     font-size: 14px;
     font-family: inherit;
     font-weight: 500;
-    transition: all 0.2s ease;
+    transition: all var(--ln-transition-base);
     outline: none;
     text-align: center;
     cursor: text;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--ln-shadow-sm);
   }
 
   .year-container {
@@ -252,41 +252,41 @@
     width: 18px;
     height: 14px;
     border: none;
-    border-radius: 3px;
+    border-radius: var(--ln-radius-sm);
     background-color: transparent;
-    color: #9ca3af;
+    color: var(--ln-color-icon-muted);
     cursor: pointer;
-    transition: all 0.15s ease;
+    transition: all var(--ln-transition-fast);
     outline: none;
     padding: 0;
   }
 
   .year-spinner:hover {
-    background-color: #f3f4f6;
-    color: #6b7280;
+    background-color: var(--ln-color-surface-hover);
+    color: var(--ln-color-icon);
   }
 
   .year-spinner:focus {
-    background-color: #e5e7eb;
-    color: #374151;
+    background-color: var(--ln-color-surface-active);
+    color: var(--ln-color-text);
   }
 
   .year-spinner:active {
-    background-color: #d1d5db;
+    background-color: var(--ln-color-border);
     transform: scale(0.9);
   }
 
   .date-input:hover {
-    border-color: #9ca3af;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    border-color: var(--ln-color-icon-muted);
+    box-shadow: var(--ln-shadow-md);
     transform: translateY(-1px);
   }
 
   .date-input:focus {
-    border-color: #3b82f6;
+    border-color: var(--ln-color-focus);
     box-shadow:
-      0 0 0 3px rgba(59, 130, 246, 0.1),
-      0 2px 6px rgba(0, 0, 0, 0.15);
+      0 0 0 3px var(--ln-color-focus-ring),
+      var(--ln-shadow-md);
     transform: translateY(-1px);
   }
 
@@ -301,5 +301,11 @@
   .year-input[type="number"] {
     appearance: textfield;
     -moz-appearance: textfield;
+  }
+
+  @media (max-width: 768px) {
+    .date-input {
+      min-height: var(--ln-space-touch);
+    }
   }
 </style>

--- a/website/src/lib/menu/DatePicker.svelte
+++ b/website/src/lib/menu/DatePicker.svelte
@@ -2,8 +2,13 @@
   import { constrainedDate } from "../data/date_utils";
   import DropdownMenu from "./DropdownMenu.svelte";
 
+  /** @typedef {number | "all"} DatePart */
+  /** @typedef {{ year: number, month: DatePart, day: DatePart }} DateValue */
+  /** @typedef {"year" | "month" | "day"} DateField */
+
   // Define a date object to hold the values
-  let { date = $bindable({ year: 1810, month: 3, day: "all" }) } = $props();
+  let { date = $bindable({ year: 1810, month: 3, day: "all" }) } =
+    /** @type {{ date?: DateValue }} */ ($props());
 
   // Add an array of month abbreviations
   const monthAbbreviations = [
@@ -26,16 +31,25 @@
   const firstYearRequiringMonth = 3000;
   const firstYearRequiringDay = 3000;
 
+  /**
+   * @param {number} year
+   * @param {number} month
+   */
   function getDaysInMonth(year, month) {
     return new Date(year < 0 ? year + 1 : year, month, 0).getDate();
   }
 
+  /**
+   * @param {DateField} field
+   * @param {DatePart} value
+   */
   function updateDate(field, value) {
     if (field === "year" && value === 0) {
       // If setting year to 0, change to -1 if current year is positive, or 1 otherwise
       value = date.year > 0 ? -1 : 1;
     }
-    date = constrainedDate({ ...date, [field]: value });
+    const nextDate = /** @type {DateValue} */ ({ ...date, [field]: value });
+    date = /** @type {DateValue} */ (constrainedDate(nextDate));
   }
 
   function incrementYear() {
@@ -56,10 +70,12 @@
     }
   }
 
+  /** @param {DatePart} value */
   function handleDaySelect(value) {
     updateDate("day", value);
   }
 
+  /** @param {DatePart} value */
   function handleMonthSelect(value) {
     updateDate("month", value);
   }
@@ -70,7 +86,9 @@
     if (date.year < firstYearRequiringDay) {
       options.push({ value: "all", label: "All" });
     }
-    for (let i = 1; i <= getDaysInMonth(date.year, date.month); i++) {
+    const daysInMonth =
+      date.month === "all" ? 0 : getDaysInMonth(date.year, date.month);
+    for (let i = 1; i <= daysInMonth; i++) {
       options.push({ value: i, label: i.toString() });
     }
     return options;
@@ -102,6 +120,7 @@
       options={dayOptions}
       displayValue={dayDisplayValue}
       minWidth="72px"
+      ariaLabel="Day"
       onSelect={handleDaySelect}
     />
   {/if}
@@ -111,6 +130,7 @@
     options={monthOptions}
     displayValue={monthDisplayValue}
     minWidth="128px"
+    ariaLabel="Month"
     onSelect={handleMonthSelect}
   />
 
@@ -132,7 +152,6 @@
         onclick={incrementYear}
         aria-label="Increment year"
         title="Increment year"
-        tabindex="-1"
       >
         <svg
           width="10"
@@ -153,7 +172,6 @@
         onclick={decrementYear}
         aria-label="Decrement year"
         title="Decrement year"
-        tabindex="-1"
       >
         <svg
           width="10"
@@ -281,6 +299,7 @@
 
   /* Firefox number input styling */
   .year-input[type="number"] {
+    appearance: textfield;
     -moz-appearance: textfield;
   }
 </style>

--- a/website/src/lib/menu/DatePicker.svelte
+++ b/website/src/lib/menu/DatePicker.svelte
@@ -101,7 +101,7 @@
       bind:value={date.day}
       options={dayOptions}
       displayValue={dayDisplayValue}
-      minWidth="60px"
+      minWidth="72px"
       onSelect={handleDaySelect}
     />
   {/if}
@@ -110,7 +110,7 @@
     bind:value={date.month}
     options={monthOptions}
     displayValue={monthDisplayValue}
-    minWidth="75px"
+    minWidth="128px"
     onSelect={handleMonthSelect}
   />
 
@@ -183,10 +183,11 @@
     padding: 8px;
     width: fit-content;
     margin: 0 auto;
-    gap: 4px;
+    gap: 8px;
   }
 
   .date-input {
+    box-sizing: border-box;
     padding: 8px 12px;
     border: 1px solid #d1d5db;
     border-radius: 8px;
@@ -205,10 +206,11 @@
   .year-container {
     position: relative;
     display: inline-block;
+    flex: 0 0 auto;
   }
 
   .year-input {
-    width: 65px;
+    width: 104px;
     cursor: text;
     background-image: none;
     padding-right: 28px;

--- a/website/src/lib/menu/DropdownMenu.svelte
+++ b/website/src/lib/menu/DropdownMenu.svelte
@@ -225,32 +225,32 @@
     align-items: center;
     justify-content: space-between;
     padding: 8px 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    background-color: #ffffff;
-    color: #374151;
+    border: 1px solid var(--ln-color-border);
+    border-radius: var(--ln-radius-lg);
+    background-color: var(--ln-color-surface);
+    color: var(--ln-color-text);
     font-size: 14px;
     font-family: inherit;
     font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: all var(--ln-transition-base);
     outline: none;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--ln-shadow-sm);
     width: 100%;
     text-align: left;
   }
 
   .dropdown-trigger:hover:not(.disabled) {
-    border-color: #9ca3af;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    border-color: var(--ln-color-icon-muted);
+    box-shadow: var(--ln-shadow-md);
     transform: translateY(-1px);
   }
 
   .dropdown-trigger:focus:not(.disabled) {
-    border-color: #3b82f6;
+    border-color: var(--ln-color-focus);
     box-shadow:
-      0 0 0 3px rgba(59, 130, 246, 0.1),
-      0 2px 6px rgba(0, 0, 0, 0.15);
+      0 0 0 3px var(--ln-color-focus-ring),
+      var(--ln-shadow-md);
     transform: translateY(-1px);
   }
 
@@ -269,8 +269,8 @@
 
   .dropdown-arrow {
     margin-left: 8px;
-    color: #9ca3af;
-    transition: transform 0.2s ease;
+    color: var(--ln-color-icon-muted);
+    transition: transform var(--ln-transition-base);
     flex-shrink: 0;
   }
 
@@ -282,10 +282,10 @@
     position: absolute;
     top: 100%;
     left: 0;
-    background: #ffffff;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    background: var(--ln-color-surface);
+    border: 1px solid var(--ln-color-border);
+    border-radius: var(--ln-radius-lg);
+    box-shadow: var(--ln-shadow-lg);
     z-index: 1000;
     margin-top: 4px;
     overflow-y: auto;
@@ -317,11 +317,11 @@
     font-size: 14px;
     font-family: inherit;
     font-weight: 500;
-    color: #374151;
-    transition: background-color 0.15s ease;
+    color: var(--ln-color-text);
+    transition: background-color var(--ln-transition-fast);
     outline: none;
     white-space: nowrap;
-    border-bottom: 1px solid #f3f4f6;
+    border-bottom: 1px solid var(--ln-color-border-muted);
   }
 
   .dropdown-item:last-child {
@@ -330,25 +330,25 @@
 
   .dropdown-item:hover,
   .dropdown-item.active {
-    background-color: #f8fafc;
-    color: #2563eb;
+    background-color: var(--ln-color-surface-muted);
+    color: var(--ln-color-primary-hover);
   }
 
   .dropdown-item:focus {
-    background-color: #f8fafc;
-    color: #2563eb;
-    outline: 2px solid #3b82f6;
+    background-color: var(--ln-color-surface-muted);
+    color: var(--ln-color-primary-hover);
+    outline: 2px solid var(--ln-color-focus);
     outline-offset: -2px;
   }
 
   .dropdown-item.selected {
-    background-color: #3b82f6;
-    color: #ffffff;
+    background-color: var(--ln-color-primary);
+    color: var(--ln-color-surface);
     font-weight: 600;
   }
 
   .dropdown-item.selected:hover {
-    background-color: #2563eb;
+    background-color: var(--ln-color-primary-hover);
   }
 
   /* Custom scrollbar for dropdown menus */
@@ -357,16 +357,23 @@
   }
 
   .dropdown-menu::-webkit-scrollbar-track {
-    background: #f1f5f9;
+    background: var(--ln-color-surface-muted);
     border-radius: 3px;
   }
 
   .dropdown-menu::-webkit-scrollbar-thumb {
-    background: #cbd5e1;
+    background: var(--ln-color-border);
     border-radius: 3px;
   }
 
   .dropdown-menu::-webkit-scrollbar-thumb:hover {
-    background: #94a3b8;
+    background: var(--ln-color-icon-muted);
+  }
+
+  @media (max-width: 768px) {
+    .dropdown-trigger,
+    .dropdown-item {
+      min-height: var(--ln-space-touch);
+    }
   }
 </style>

--- a/website/src/lib/menu/DropdownMenu.svelte
+++ b/website/src/lib/menu/DropdownMenu.svelte
@@ -12,6 +12,7 @@
     placeholder = "Select...",
     minWidth = "60px",
     maxHeight = "200px",
+    ariaLabel = undefined,
     disabled = false,
     onSelect = () => {},
   } = $props();
@@ -164,6 +165,7 @@
     aria-haspopup="listbox"
     aria-controls={listboxId}
     aria-activedescendant={activeDescendantId}
+    aria-label={ariaLabel}
     aria-disabled={disabled}
   >
     <span class="dropdown-value">{displayValue || placeholder}</span>

--- a/website/src/lib/menu/DropdownMenu.svelte
+++ b/website/src/lib/menu/DropdownMenu.svelte
@@ -1,4 +1,10 @@
+<script module>
+  let dropdownIdCounter = 0;
+</script>
+
 <script>
+  /** @typedef {{ value: string | number, label: string }} DropdownOption */
+
   let {
     value = $bindable(),
     options = [],
@@ -11,47 +17,154 @@
   } = $props();
 
   let isOpen = $state(false);
-  let dropdownContainer;
+  let activeOptionIndex = $state(-1);
+  /** @type {HTMLElement | null} */
+  let dropdownContainer = null;
+  const dropdownId = `dropdown-${++dropdownIdCounter}`;
+  const triggerId = `${dropdownId}-trigger`;
+  const listboxId = `${dropdownId}-listbox`;
+  const selectedOptionIndex = $derived(
+    options.findIndex((option) => option.value === value)
+  );
+  const activeOption = $derived(
+    isOpen && activeOptionIndex >= 0 ? options[activeOptionIndex] : null
+  );
+  const activeDescendantId = $derived(
+    activeOption ? getOptionId(activeOption) : undefined
+  );
 
   function toggleDropdown() {
     if (!disabled) {
-      isOpen = !isOpen;
+      if (isOpen) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
     }
   }
 
+  /** @param {number} [index] */
+  function openDropdown(index = selectedOptionIndex >= 0 ? selectedOptionIndex : 0) {
+    if (disabled) return;
+    isOpen = true;
+    activeOptionIndex = options.length > 0 ? index : -1;
+  }
+
+  function closeDropdown() {
+    isOpen = false;
+    activeOptionIndex = -1;
+  }
+
+  /**
+   * @param {string | number} optionValue
+   * @param {string} optionLabel
+   */
   function selectOption(optionValue, optionLabel) {
     value = optionValue;
     onSelect(optionValue, optionLabel);
-    isOpen = false;
+    closeDropdown();
   }
 
+  /** @param {MouseEvent} event */
   function handleClickOutside(event) {
-    if (dropdownContainer && !dropdownContainer.contains(event.target)) {
-      isOpen = false;
+    if (dropdownContainer && event.target instanceof Node && !dropdownContainer.contains(event.target)) {
+      closeDropdown();
     }
   }
 
-  function handleKeydown(event) {
+  /** @param {KeyboardEvent} event */
+  function handleWindowKeydown(event) {
     if (event.key === "Escape") {
-      isOpen = false;
+      closeDropdown();
     }
+  }
+
+  /** @param {KeyboardEvent} event */
+  function handleTriggerKeydown(event) {
+    if (disabled) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (!isOpen) {
+        openDropdown();
+      } else {
+        moveActiveOption(1);
+      }
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (!isOpen) {
+        openDropdown(options.length - 1);
+      } else {
+        moveActiveOption(-1);
+      }
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      openDropdown(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      openDropdown(options.length - 1);
+    } else if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (isOpen && activeOption) {
+        selectOption(activeOption.value, activeOption.label);
+      } else {
+        openDropdown();
+      }
+    } else if (event.key === "Escape" && isOpen) {
+      event.preventDefault();
+      closeDropdown();
+    }
+  }
+
+  /** @param {number} offset */
+  function moveActiveOption(offset) {
+    if (options.length === 0) return;
+    const startingIndex = activeOptionIndex >= 0 ? activeOptionIndex : 0;
+    activeOptionIndex =
+      (startingIndex + offset + options.length) % options.length;
+  }
+
+  /** @param {DropdownOption} option */
+  function getOptionId(option) {
+    return `${dropdownId}-option-${String(option.value).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  }
+
+  /** @param {number} index */
+  function handleOptionMouseEnter(index) {
+    activeOptionIndex = index;
+  }
+
+  /** @param {DropdownOption} option */
+  function handleOptionClick(option) {
+    selectOption(option.value, option.label);
+  }
+
+  /** @param {number} index */
+  function isActiveOption(index) {
+    return isOpen && activeOptionIndex === index;
   }
 </script>
 
-<svelte:window onclick={handleClickOutside} onkeydown={handleKeydown} />
+<svelte:window onclick={handleClickOutside} onkeydown={handleWindowKeydown} />
 
 <div
   class="dropdown-container"
   bind:this={dropdownContainer}
   style="min-width: {minWidth}"
 >
-  <button
+  <div
+    id={triggerId}
     class="dropdown-trigger"
     class:disabled
     onclick={toggleDropdown}
+    onkeydown={handleTriggerKeydown}
+    role="combobox"
+    tabindex={disabled ? -1 : 0}
     aria-expanded={isOpen}
     aria-haspopup="listbox"
-    {disabled}
+    aria-controls={listboxId}
+    aria-activedescendant={activeDescendantId}
+    aria-disabled={disabled}
   >
     <span class="dropdown-value">{displayValue || placeholder}</span>
     <svg
@@ -68,17 +181,27 @@
     >
       <polyline points="6,9 12,15 18,9"></polyline>
     </svg>
-  </button>
+  </div>
 
   {#if isOpen}
-    <div class="dropdown-menu" role="listbox" style="max-height: {maxHeight}">
-      {#each options as option}
+    <div
+      id={listboxId}
+      class="dropdown-menu"
+      role="listbox"
+      aria-labelledby={triggerId}
+      style="max-height: {maxHeight}"
+    >
+      {#each options as option, index (option.value)}
         <button
+          id={getOptionId(option)}
           class="dropdown-item"
           class:selected={value === option.value}
-          onclick={() => selectOption(option.value, option.label)}
+          class:active={isActiveOption(index)}
+          onclick={() => handleOptionClick(option)}
+          onmouseenter={() => handleOptionMouseEnter(index)}
           role="option"
           aria-selected={value === option.value}
+          tabindex="-1"
         >
           {option.label}
         </button>
@@ -91,9 +214,11 @@
   .dropdown-container {
     position: relative;
     display: inline-block;
+    flex: 0 0 auto;
   }
 
   .dropdown-trigger {
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -201,7 +326,8 @@
     border-bottom: none;
   }
 
-  .dropdown-item:hover {
+  .dropdown-item:hover,
+  .dropdown-item.active {
     background-color: #f8fafc;
     color: #2563eb;
   }

--- a/website/src/lib/menu/MenuDropdown.svelte
+++ b/website/src/lib/menu/MenuDropdown.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount, onDestroy } from "svelte";
   import { appState } from "../appState.svelte";
   import DropdownMenu from "./DropdownMenu.svelte";
 
@@ -14,8 +13,13 @@
     setTimeout(onCloseMenu, 200);
   }
 
+  /** @param {MouseEvent} event */
   function handleClickOutside(event) {
     // Close menu when clicking outside
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+
     if (
       !event.target.closest(".menu-container") &&
       !event.target.closest(".menu-button")
@@ -24,8 +28,24 @@
     }
   }
 
+  /** @param {string} value */
   function handleDateFilterSelect(value) {
     strictDate = value === "strict";
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is { name: string, message: string }}
+   */
+  function hasErrorDetails(value) {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "name" in value &&
+      typeof value.name === "string" &&
+      "message" in value &&
+      typeof value.message === "string"
+    );
   }
 
   async function handleShareLink() {
@@ -46,10 +66,17 @@
         alert("Link copied to clipboard");
       }
     } catch (error) {
-      console.log("Share operation failed:", error.name, error.message);
+      const shareError = hasErrorDetails(error)
+        ? error
+        : { name: "Error", message: String(error) };
+
+      console.log("Share operation failed:", shareError.name, shareError.message);
 
       // Check if it's a user cancellation (common with navigator.share)
-      if (error.name === "AbortError" || error.message.includes("canceled")) {
+      if (
+        shareError.name === "AbortError" ||
+        shareError.message.includes("canceled")
+      ) {
         console.log("User canceled the share operation");
         // Don't show fallback for user cancellation
         onCloseMenu();
@@ -74,26 +101,15 @@
     { value: "strict", label: "Only events strictly within the date" },
   ];
 
-  let dateFilterValue = $state(strictDate ? "strict" : "overlapping");
+  const dateFilterValue = $derived(strictDate ? "strict" : "overlapping");
   const dateFilterDisplayValue = $derived(
     strictDate
       ? "Only events strictly within the date"
       : "All events overlapping with the date"
   );
-
-  // Sync the internal state with the prop
-  $effect(() => {
-    dateFilterValue = strictDate ? "strict" : "overlapping";
-  });
-
-  onMount(() => {
-    document.addEventListener("click", handleClickOutside);
-  });
-
-  onDestroy(() => {
-    document.removeEventListener("click", handleClickOutside);
-  });
 </script>
+
+<svelte:document onclick={handleClickOutside} />
 
 <div class="menu-container">
   <div class="menu-dropdown" onblur={handleMenuBlur} tabindex="-1">
@@ -121,10 +137,11 @@
       <div class="menu-group">
         <span class="menu-label">Date filter</span>
         <DropdownMenu
-          bind:value={dateFilterValue}
+          value={dateFilterValue}
           options={dateFilterOptions}
           displayValue={dateFilterDisplayValue}
           minWidth="280px"
+          ariaLabel="Date filter"
           onSelect={handleDateFilterSelect}
         />
       </div>

--- a/website/src/lib/menu/MenuDropdown.svelte
+++ b/website/src/lib/menu/MenuDropdown.svelte
@@ -215,10 +215,10 @@
     top: 100%;
     left: 0;
     right: 0;
-    background: white;
-    border: 1px solid #d1d5db;
-    border-radius: 12px;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    background: var(--ln-color-surface);
+    border: 1px solid var(--ln-color-border);
+    border-radius: var(--ln-radius-xl);
+    box-shadow: var(--ln-shadow-lg);
     z-index: 1000;
     max-height: 300px;
     overflow-y: auto;
@@ -229,7 +229,7 @@
 
   .menu-group {
     padding: 12px 16px;
-    border-bottom: 1px solid #f3f4f6;
+    border-bottom: 1px solid var(--ln-color-border-muted);
     display: flex;
     align-items: center;
     gap: 12px;
@@ -242,7 +242,7 @@
 
   .menu-label {
     font-weight: 600;
-    color: #374151;
+    color: var(--ln-color-text);
     font-size: 14px;
     min-width: fit-content;
   }
@@ -256,63 +256,63 @@
 
   .mode-option {
     padding: 6px 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    background-color: #ffffff;
-    color: #374151;
+    border: 1px solid var(--ln-color-border);
+    border-radius: var(--ln-radius-lg);
+    background-color: var(--ln-color-surface);
+    color: var(--ln-color-text);
     cursor: pointer;
     font-size: 14px;
     font-family: inherit;
     font-weight: 500;
     white-space: nowrap;
-    transition: all 0.2s ease;
+    transition: all var(--ln-transition-base);
     outline: none;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--ln-shadow-sm);
   }
 
   .mode-option:hover {
-    background-color: #f9fafb;
-    border-color: #9ca3af;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    background-color: var(--ln-color-surface-muted);
+    border-color: var(--ln-color-icon-muted);
+    box-shadow: var(--ln-shadow-md);
     transform: translateY(-1px);
   }
 
   .mode-option:focus {
-    border-color: #3b82f6;
+    border-color: var(--ln-color-focus);
     box-shadow:
-      0 0 0 3px rgba(59, 130, 246, 0.1),
-      0 2px 6px rgba(0, 0, 0, 0.15);
+      0 0 0 3px var(--ln-color-focus-ring),
+      var(--ln-shadow-md);
     transform: translateY(-1px);
   }
 
   .mode-option:active {
-    background-color: #f3f4f6;
+    background-color: var(--ln-color-surface-hover);
     transform: translateY(0);
   }
 
   .mode-option.active {
-    background-color: #3b82f6;
-    color: white;
-    border-color: #3b82f6;
-    box-shadow: 0 2px 6px rgba(59, 130, 246, 0.3);
+    background-color: var(--ln-color-primary);
+    color: var(--ln-color-surface);
+    border-color: var(--ln-color-primary);
+    box-shadow: var(--ln-shadow-primary-sm);
   }
 
   .mode-option.active:hover {
-    background-color: #2563eb;
-    border-color: #2563eb;
-    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.4);
+    background-color: var(--ln-color-primary-hover);
+    border-color: var(--ln-color-primary-hover);
+    box-shadow: var(--ln-shadow-primary-md);
   }
 
   .menu-item {
     display: block;
     padding: 12px 16px;
     text-decoration: none;
-    color: #3b82f6;
-    border-bottom: 1px solid #f3f4f6;
+    color: var(--ln-color-primary);
+    border-bottom: 1px solid var(--ln-color-border-muted);
     cursor: pointer;
     font-size: 15px;
     font-weight: 500;
-    transition: all 0.2s ease;
+    transition: all var(--ln-transition-base);
   }
 
   .menu-item:last-child {
@@ -320,30 +320,30 @@
   }
 
   .menu-item:hover {
-    background-color: #f8fafc;
-    color: #2563eb;
+    background-color: var(--ln-color-surface-muted);
+    color: var(--ln-color-primary-hover);
     text-decoration: none;
   }
 
   .menu-item:focus {
-    background-color: #f8fafc;
-    outline: 2px solid #3b82f6;
+    background-color: var(--ln-color-surface-muted);
+    outline: 2px solid var(--ln-color-focus);
     outline-offset: -2px;
-    color: #2563eb;
+    color: var(--ln-color-primary-hover);
   }
 
   .menu-links {
-    border-top: 1px solid #f3f4f6;
+    border-top: 1px solid var(--ln-color-border-muted);
   }
 
   .share-status {
     min-height: 20px;
     padding: 0 16px 8px;
-    color: #166534;
+    color: var(--ln-color-success);
     font-size: 13px;
   }
 
   .share-status.error {
-    color: #b91c1c;
+    color: var(--ln-color-danger);
   }
 </style>

--- a/website/src/lib/menu/MenuDropdown.svelte
+++ b/website/src/lib/menu/MenuDropdown.svelte
@@ -7,6 +7,21 @@
     strictDate = $bindable(false),
     onCloseMenu,
   } = $props();
+  let shareStatus = $state("");
+  let shareStatusType = $state("success");
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let closeAfterStatusTimeout;
+
+  /** @param {string} message */
+  function setShareStatus(message, type = "success") {
+    shareStatus = message;
+    shareStatusType = type;
+  }
+
+  function closeAfterStatus() {
+    clearTimeout(closeAfterStatusTimeout);
+    closeAfterStatusTimeout = setTimeout(onCloseMenu, 1600);
+  }
 
   function handleMenuBlur() {
     // Small delay to allow click events on menu items to fire
@@ -60,10 +75,14 @@
         });
         // If we reach here, sharing was successful
         console.log("Share completed successfully");
+        onCloseMenu();
+        return;
       } else {
         // Copy to clipboard on desktop
         await navigator.clipboard.writeText(currentUrl);
-        alert("Link copied to clipboard");
+        setShareStatus("Link copied to clipboard.");
+        closeAfterStatus();
+        return;
       }
     } catch (error) {
       const shareError = hasErrorDetails(error)
@@ -86,14 +105,13 @@
       // Fallback: copy to clipboard for other errors
       try {
         await navigator.clipboard.writeText(currentUrl);
-        alert("Link copied to clipboard!");
+        setShareStatus("Link copied to clipboard.");
+        closeAfterStatus();
       } catch (clipboardError) {
         console.error("Failed to share or copy link:", error, clipboardError);
-        alert("Failed to copy link to clipboard");
+        setShareStatus("Unable to copy link. Please try again.", "error");
       }
     }
-
-    onCloseMenu();
   }
 
   const dateFilterOptions = [
@@ -162,6 +180,9 @@
       >
         Share the link for the current view
       </span>
+      <div class="share-status {shareStatusType}" role="status" aria-live="polite">
+        {shareStatus}
+      </div>
       <span
         onclick={() => {
           appState.paneTab = "about";
@@ -313,5 +334,16 @@
 
   .menu-links {
     border-top: 1px solid #f3f4f6;
+  }
+
+  .share-status {
+    min-height: 20px;
+    padding: 0 16px 8px;
+    color: #166534;
+    font-size: 13px;
+  }
+
+  .share-status.error {
+    color: #b91c1c;
   }
 </style>

--- a/website/src/lib/menu/SearchBarMenu.svelte
+++ b/website/src/lib/menu/SearchBarMenu.svelte
@@ -13,8 +13,17 @@
   let selectedIndex = $state(-1); // Track the currently selected suggestion
   let isMenuOpen = $state(false); // State for menu dropdown visibility
 
+  /** @type {ReturnType<typeof setTimeout> | null} */
   let debounceTimer = null;
+  let searchRequestId = 0;
   const basePath = import.meta.env.BASE_URL;
+  const searchInputId = "search-input";
+  const searchResultsId = "search-results";
+  const activeDescendantId = $derived(
+    isActive && selectedIndex >= 0 && searchResults[selectedIndex]
+      ? getSearchOptionId(searchResults[selectedIndex])
+      : undefined
+  );
 
   // Debounced search function
   function debouncedSearch() {
@@ -22,15 +31,25 @@
 
     // Clear any existing timer
     if (debounceTimer) clearTimeout(debounceTimer);
+    const requestId = ++searchRequestId;
 
     // Set a new timer
     debounceTimer = setTimeout(async () => {
-      if (searchQuery && searchQuery.length > 1) {
+      const query = searchQuery;
+      const searchMode = appState.mode === "events" ? "pages" : "places";
+
+      if (query && query.length > 1) {
         // Different API endpoints based on mode
-        const searchMode = appState.mode === "events" ? "pages" : "places";
-        searchResults = await getEntriesfromText(searchQuery, searchMode);
+        const results = await getEntriesfromText(query, searchMode);
+        if (requestId !== searchRequestId) {
+          return;
+        }
+        searchResults = results;
         isActive = true;
       } else {
+        if (requestId !== searchRequestId) {
+          return;
+        }
         searchResults = [];
         isActive = false;
       }
@@ -45,6 +64,7 @@
       searchResults = [];
       debouncedSearch();
     } else {
+      searchRequestId += 1;
       searchResults = [];
       isActive = false;
       isLoading = false;
@@ -119,6 +139,30 @@
     selectedIndex = -1;
   }
 
+  function clearSearch() {
+    searchRequestId += 1;
+    searchQuery = "";
+    searchResults = [];
+    isActive = false;
+    selectedIndex = -1;
+    isLoading = false;
+    if (debounceTimer) clearTimeout(debounceTimer);
+  }
+
+  /**
+   * @param {{ id?: string | number, geokey?: string | number, page_title?: string }} entry
+   */
+  function getSearchResultKey(entry) {
+    return entry.id ?? entry.geokey ?? entry.page_title;
+  }
+
+  /**
+   * @param {{ id?: string | number, geokey?: string | number, page_title?: string }} entry
+   */
+  function getSearchOptionId(entry) {
+    return `search-option-${String(getSearchResultKey(entry)).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  }
+
   function handleBlur() {
     // Small delay to allow click events on suggestions to fire
     setTimeout(() => {
@@ -138,6 +182,7 @@
 <div class="search-container">
   <div class="search-input-wrapper">
     <input
+      id={searchInputId}
       type="text"
       placeholder={`Search a ${appState.mode === "places" ? "place" : "page"}`}
       bind:value={searchQuery}
@@ -145,14 +190,18 @@
       onblur={handleBlur}
       onkeydown={handleKeydown}
       class="search-input"
+      role="combobox"
+      aria-autocomplete="list"
+      aria-expanded={isActive}
+      aria-controls={searchResultsId}
+      aria-activedescendant={activeDescendantId}
     />
     {#if searchQuery}
       <button
         class="clear-button"
-        onclick={() => {
-          searchQuery = "";
-          isActive = false;
-        }}
+        onclick={clearSearch}
+        aria-label="Clear search"
+        title="Clear search"
       >
         ×
       </button>
@@ -176,9 +225,10 @@
   </div>
 
   {#if isActive && searchResults.length > 0}
-    <div class="suggestions" role="listbox">
-      {#each searchResults as entry, i}
+    <div class="suggestions" id={searchResultsId} role="listbox" aria-labelledby={searchInputId}>
+      {#each searchResults as entry, i (getSearchResultKey(entry))}
         <div
+          id={getSearchOptionId(entry)}
           class="suggestion-item {i === selectedIndex ? 'selected' : ''}"
           onmousedown={() => handleSelect(entry)}
           role="option"
@@ -199,7 +249,7 @@
       {/each}
     </div>
   {:else if isActive && searchQuery.length > 1}
-    <div class="suggestions" role="listbox">
+    <div class="suggestions" id={searchResultsId} role="listbox" aria-labelledby={searchInputId}>
       <div class="no-results" role="presentation">
         {#if isLoading}
           Searching...

--- a/website/src/lib/menu/SearchBarMenu.svelte
+++ b/website/src/lib/menu/SearchBarMenu.svelte
@@ -6,7 +6,18 @@
 
   import { appState, uiGlobals, uiState } from "../appState.svelte";
 
+  /**
+   * @typedef {Object} SearchEntry
+   * @property {string | number} [id]
+   * @property {*} [geokey]
+   * @property {string} page_title
+   * @property {number} lat
+   * @property {number} lon
+   * @property {number} [n_events]
+   */
+
   let searchQuery = $state("");
+  /** @type {SearchEntry[]} */
   let searchResults = $state([]);
   let isActive = $state(false);
   let isLoading = $state(false);
@@ -23,6 +34,11 @@
     isActive && selectedIndex >= 0 && searchResults[selectedIndex]
       ? getSearchOptionId(searchResults[selectedIndex])
       : undefined
+  );
+  const noResultsMessage = $derived(
+    appState.mode === "events"
+      ? "No matching pages or events found"
+      : "No matching locations found"
   );
 
   // Debounced search function
@@ -95,6 +111,9 @@
     if (debounceTimer) clearTimeout(debounceTimer);
   });
 
+  /**
+   * @param {KeyboardEvent} event
+   */
   function handleKeydown(event) {
     if (!isActive || searchResults.length === 0) return;
 
@@ -113,6 +132,9 @@
     }
   }
 
+  /**
+   * @param {SearchEntry} entry
+   */
   function handleSelect(entry) {
     if (appState.mode === "places") {
       const { geokey, lat, lon, page_title } = entry;
@@ -123,7 +145,9 @@
       appState.wikiSection = "";
       appState.wikiPage = page_title;
       appState.paneTab = "wikipedia";
-      uiGlobals.mapTravel({
+      /** @type {(options: { location: { lat: number, lon: number }, zoom: number, flyDuration: number }) => void} */ (
+        /** @type {unknown} */ (uiGlobals.mapTravel)
+      )({
         location: { lat, lon },
         zoom: Math.max(12, appState.zoom),
         flyDuration: 1,
@@ -139,6 +163,17 @@
     selectedIndex = -1;
   }
 
+  /**
+   * @param {KeyboardEvent} event
+   * @param {SearchEntry} entry
+   */
+  function handleSuggestionKeydown(event, entry) {
+    if (event.key !== "Enter" && event.key !== " ") return;
+
+    event.preventDefault();
+    handleSelect(entry);
+  }
+
   function clearSearch() {
     searchRequestId += 1;
     searchQuery = "";
@@ -150,14 +185,14 @@
   }
 
   /**
-   * @param {{ id?: string | number, geokey?: string | number, page_title?: string }} entry
+   * @param {SearchEntry} entry
    */
   function getSearchResultKey(entry) {
     return entry.id ?? entry.geokey ?? entry.page_title;
   }
 
   /**
-   * @param {{ id?: string | number, geokey?: string | number, page_title?: string }} entry
+   * @param {SearchEntry} entry
    */
   function getSearchOptionId(entry) {
     return `search-option-${String(getSearchResultKey(entry)).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
@@ -210,17 +245,27 @@
       <img src={`${import.meta.env.BASE_URL}icons/search.svg`} alt="Search" />
     </div>
 
+    <div class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {#if uiState.dataIsLoading}
+        Loading data...
+      {/if}
+    </div>
+    <div class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {#if isLoading}
+        Searching...
+      {/if}
+    </div>
+
     <!-- Menu button wrapper with the hamburger icon now here -->
     <div class="menu-button-wrapper">
       {#if uiState.dataIsLoading}
-        <div class="menu-button loading" title="Loading...">
+        <div class="menu-loading-indicator" title="Loading data" aria-hidden="true">
           <div class="spinner"></div>
         </div>
-      {:else}
-        <button class="menu-button" onclick={toggleMenu} title="Menu">
-          <img src={`${basePath}icons/menu.svg`} alt="Menu" class="icon" />
-        </button>
       {/if}
+      <button class="menu-button" onclick={toggleMenu} title="Menu" aria-label="Menu">
+        <img src={`${basePath}icons/menu.svg`} alt="" class="icon" />
+      </button>
     </div>
   </div>
 
@@ -231,6 +276,7 @@
           id={getSearchOptionId(entry)}
           class="suggestion-item {i === selectedIndex ? 'selected' : ''}"
           onmousedown={() => handleSelect(entry)}
+          onkeydown={(event) => handleSuggestionKeydown(event, entry)}
           role="option"
           aria-selected={i === selectedIndex}
           tabindex="0"
@@ -254,7 +300,7 @@
         {#if isLoading}
           Searching...
         {:else}
-          No matching locations found
+          {noResultsMessage}
         {/if}
       </div>
     </div>
@@ -341,6 +387,13 @@
     padding: 0;
   }
 
+  .menu-loading-indicator {
+    position: absolute;
+    right: -2px;
+    top: -2px;
+    pointer-events: none;
+  }
+
   .menu-button-wrapper:hover {
     background-color: #eee;
   }
@@ -415,10 +468,10 @@
   }
 
   .spinner {
-    width: 18px;
-    height: 18px;
-    border: 3px solid #e0e0e0;
-    border-top: 3px solid #666;
+    width: 10px;
+    height: 10px;
+    border: 2px solid #e0e0e0;
+    border-top: 2px solid #666;
     border-radius: 50%;
     animation: spin 1s linear infinite;
   }
@@ -432,7 +485,15 @@
     }
   }
 
-  .menu-button.loading {
-    cursor: wait;
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 </style>

--- a/website/src/lib/menu/SearchBarMenu.svelte
+++ b/website/src/lib/menu/SearchBarMenu.svelte
@@ -145,12 +145,13 @@
       appState.wikiSection = "";
       appState.wikiPage = page_title;
       appState.paneTab = "wikipedia";
-      /** @type {(options: { location: { lat: number, lon: number }, zoom: number, flyDuration: number }) => void} */ (
+      /** @type {(options: { location: { lat: number, lon: number }, zoom: number, flyDuration: number, reserveMobilePane?: boolean }) => void} */ (
         /** @type {unknown} */ (uiGlobals.mapTravel)
       )({
         location: { lat, lon },
         zoom: Math.max(12, appState.zoom),
         flyDuration: 1,
+        reserveMobilePane: true,
       });
     } else {
       const { page_title } = entry;

--- a/website/src/lib/menu/SearchBarMenu.svelte
+++ b/website/src/lib/menu/SearchBarMenu.svelte
@@ -331,33 +331,35 @@
     position: relative;
     display: flex;
     align-items: center;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-    border-radius: 20px;
+    box-shadow: var(--ln-shadow-md);
+    border-radius: var(--ln-radius-pill);
     padding: 0px;
   }
 
   .search-input {
     width: 100%;
     padding: 10px 40px 10px 35px;
-    border: 1px solid #ccc;
-    border-radius: 20px;
+    border: 1px solid var(--ln-color-border);
+    border-radius: var(--ln-radius-pill);
+    background-color: var(--ln-color-surface);
+    color: var(--ln-color-text);
     font-size: 16px;
     outline: none;
     transition:
-      border-color 0.2s,
-      box-shadow 0.2s;
+      border-color var(--ln-transition-base),
+      box-shadow var(--ln-transition-base);
   }
 
   .search-input:focus {
-    border-color: #4285f4;
-    box-shadow: 0 0 0 2px rgba(66, 133, 244, 0.2);
+    border-color: var(--ln-color-focus);
+    box-shadow: 0 0 0 3px var(--ln-color-focus-ring);
   }
 
   .search-icon {
     position: absolute;
     left: 8px;
     pointer-events: none;
-    color: #666;
+    color: var(--ln-color-icon);
     height: 25px;
     opacity: 0.5;
   }
@@ -368,8 +370,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 28px;
-    width: 28px;
+    min-height: 28px;
+    min-width: 28px;
     border-radius: 50%;
     padding: 5px;
   }
@@ -378,7 +380,7 @@
     background: transparent;
     border: none;
     font-size: 18px;
-    color: #999;
+    color: var(--ln-color-icon-muted);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -396,7 +398,7 @@
   }
 
   .menu-button-wrapper:hover {
-    background-color: #eee;
+    background-color: var(--ln-color-surface-hover);
   }
 
   .clear-button {
@@ -405,7 +407,7 @@
     background: none;
     border: none;
     font-size: 20px;
-    color: #666;
+    color: var(--ln-color-icon);
     cursor: pointer;
     padding: 0;
     height: 20px;
@@ -421,27 +423,27 @@
     top: 100%;
     left: 0;
     right: 0;
-    background: white;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    background: var(--ln-color-surface);
+    border: 1px solid var(--ln-color-border);
+    border-radius: var(--ln-radius-xl);
+    box-shadow: var(--ln-shadow-lg);
     z-index: 1000;
     max-height: 300px;
     overflow-y: auto;
-    margin-top: 5px;
+    margin-top: 6px;
   }
 
   .suggestion-item {
     padding: 10px 15px;
     cursor: pointer;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--ln-color-border-muted);
     display: flex;
     justify-content: space-between;
     align-items: center;
   }
 
   .suggestion-item.selected {
-    background-color: #f0f7ff;
+    background-color: var(--ln-color-primary-soft);
   }
 
   .suggestion-item:last-child {
@@ -449,7 +451,7 @@
   }
 
   .suggestion-item:hover {
-    background-color: #f5f5f5;
+    background-color: var(--ln-color-surface-hover);
   }
 
   .suggestion-title {
@@ -458,21 +460,21 @@
 
   .suggestion-location {
     font-size: 0.8em;
-    color: #666;
+    color: var(--ln-color-text-muted);
   }
 
   .no-results {
     padding: 15px;
     text-align: center;
-    color: #666;
+    color: var(--ln-color-text-muted);
     font-style: italic;
   }
 
   .spinner {
     width: 10px;
     height: 10px;
-    border: 2px solid #e0e0e0;
-    border-top: 2px solid #666;
+    border: 2px solid var(--ln-color-border-muted);
+    border-top: 2px solid var(--ln-color-icon);
     border-radius: 50%;
     animation: spin 1s linear infinite;
   }
@@ -496,5 +498,20 @@
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+  }
+
+  @media (max-width: 768px) {
+    .menu-button-wrapper {
+      min-width: var(--ln-space-touch);
+      min-height: var(--ln-space-touch);
+      right: -3px;
+      padding: 0;
+    }
+
+    .clear-button {
+      min-width: var(--ln-space-touch);
+      min-height: var(--ln-space-touch);
+      right: 36px;
+    }
   }
 </style>

--- a/website/src/lib/sliding_pane/About.svelte
+++ b/website/src/lib/sliding_pane/About.svelte
@@ -30,7 +30,7 @@
   .about-page {
     padding: 16px;
     overflow-y: auto;
-    color: #222;
+    color: var(--ln-color-text);
     font-family: sans-serif;
   }
 
@@ -39,7 +39,7 @@
     margin-bottom: 16px;
     font-size: 1.4em;
     font-weight: normal;
-    border-bottom: 1px solid #a2a9b1;
+    border-bottom: 1px solid var(--ln-color-border-strong);
     padding-bottom: 0.2em;
     text-align: center;
   }
@@ -47,11 +47,11 @@
   p {
     margin-bottom: 16px;
     line-height: 1.5;
-    color: #222;
+    color: var(--ln-color-text);
   }
 
   a {
-    color: #0645ad;
+    color: var(--ln-color-primary);
     text-decoration: none;
   }
 
@@ -71,20 +71,21 @@
     display: block;
     margin: 20px auto;
     padding: 8px 16px;
-    background-color: #4285f4;
-    color: white;
+    min-height: var(--ln-space-touch);
+    background-color: var(--ln-color-primary);
+    color: var(--ln-color-surface);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--ln-radius-lg);
     cursor: pointer;
     font-size: 1em;
-    transition: background-color 0.2s;
+    transition: background-color var(--ln-transition-base);
   }
 
   .close-button:hover {
-    background-color: #0b57d0;
+    background-color: var(--ln-color-primary-hover);
   }
 
   .close-button:active {
-    background-color: #054a9e;
+    background-color: var(--ln-color-primary-active);
   }
 </style>

--- a/website/src/lib/sliding_pane/About.svelte
+++ b/website/src/lib/sliding_pane/About.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { appState } from "../appState.svelte";
   const { closePane } = $props();
+  const menuIconPath = `${import.meta.env.BASE_URL}icons/menu.svg`;
 </script>
 
 <div class="about-page">
@@ -8,7 +8,7 @@
 
   <p>
     Landnotes shows Wikipedia places and events on a map (see the menu
-    <img src="/icons/menu.svg" alt="menu" class="menu-icon" />
+    <img src={menuIconPath} alt="menu" class="menu-icon" />
     for options).
   </p>
 
@@ -18,7 +18,8 @@
     might be 10 times more events to extract by scanning all of Wikipedia -
     learn more on the project's <a
       href="https://github.com/Zulko/landnotes"
-      target="_blank">Github page</a
+      target="_blank"
+      rel="noreferrer">GitHub page</a
     >.
   </p>
 

--- a/website/src/lib/sliding_pane/PageEvents.svelte
+++ b/website/src/lib/sliding_pane/PageEvents.svelte
@@ -9,6 +9,11 @@
   let loadingEvents = $state(true);
   let expandedYears = $state({});
   let dataLoadedByYear = $state({});
+  const sortedYearEntries = $derived(
+    Object.entries(eventIdsByYear).sort(
+      ([yearA], [yearB]) => Number(yearA) - Number(yearB)
+    )
+  );
 
   $effect(() => {
     loadEventList(wikiPage);
@@ -75,7 +80,7 @@
   {:else if Object.keys(eventIdsByYear).length === 0}
     <div class="no-events">No events found for this page.</div>
   {:else}
-    {#each Object.entries(eventIdsByYear).sort(([yearA], [yearB]) => Number(yearA) - Number(yearB)) as [year, yearEventIds]}
+    {#each sortedYearEntries as [year, yearEventIds] (year)}
       <div class="year-section">
         <div
           class="year-header"
@@ -95,7 +100,7 @@
 
         {#if expandedYears[year]}
           <div class="year-events">
-            {#each dataLoadedByYear[year] as event}
+            {#each dataLoadedByYear[year] as event (event.id)}
               <div class="event-card-container">
                 <EventCard
                   entry={event}

--- a/website/src/lib/sliding_pane/PageEvents.svelte
+++ b/website/src/lib/sliding_pane/PageEvents.svelte
@@ -127,7 +127,7 @@
   .page-events {
     padding: 16px;
     overflow-y: auto;
-    color: #222;
+    color: var(--ln-color-text);
     font-family: sans-serif;
   }
 
@@ -135,14 +135,14 @@
     margin-bottom: 16px;
     font-size: 1.8em;
     font-weight: normal;
-    border-bottom: 1px solid #a2a9b1;
+    border-bottom: 1px solid var(--ln-color-border-strong);
     padding-bottom: 0.2em;
   }
 
   .loading,
   .no-events {
     padding: 12px 0;
-    color: #72777d;
+    color: var(--ln-color-text-subtle);
   }
 
   .year-section {
@@ -163,7 +163,7 @@
     cursor: pointer;
     user-select: none;
     border: 0;
-    border-bottom: 1px solid #eaecf0;
+    border-bottom: 1px solid var(--ln-color-border-muted);
     background: none;
     color: inherit;
     font: inherit;
@@ -171,7 +171,7 @@
   }
 
   .year-header:hover {
-    background-color: #f8f9fa;
+    background-color: var(--ln-color-surface-muted);
   }
 
   .section-title {
@@ -182,12 +182,12 @@
 
   .event-count {
     margin-right: 8px;
-    color: #72777d;
+    color: var(--ln-color-text-subtle);
     font-size: 0.85em;
   }
 
   .expand-icon {
-    color: #72777d;
+    color: var(--ln-color-text-subtle);
     font-size: 0.8em;
     width: 16px;
     text-align: center;
@@ -209,10 +209,10 @@
 
   .event-card-container {
     margin-bottom: 8px;
-    border: 1px solid #eaeaea;
-    border-radius: 6px;
+    border: 1px solid var(--ln-color-border-muted);
+    border-radius: var(--ln-radius-lg);
     padding: 12px;
-    background-color: white;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background-color: var(--ln-color-surface);
+    box-shadow: var(--ln-shadow-sm);
   }
 </style>

--- a/website/src/lib/sliding_pane/PageEvents.svelte
+++ b/website/src/lib/sliding_pane/PageEvents.svelte
@@ -70,6 +70,11 @@
       .map(normalizeMapEntryInfo)
       .sort((a, b) => a.start_date.localeCompare(b.start_date));
   }
+
+  /** @param {string} year */
+  function yearEventsId(year) {
+    return `page-events-year-${year}-events`;
+  }
 </script>
 
 <div class="page-events">
@@ -82,24 +87,26 @@
   {:else}
     {#each sortedYearEntries as [year, yearEventIds] (year)}
       <div class="year-section">
-        <div
-          class="year-header"
-          onclick={() => toggleYear(year)}
-          onkeydown={(e) => e.key === "Enter" && toggleYear(year)}
-          role="button"
-          tabindex="0"
-        >
-          <h2>{year}</h2>
-          <span class="event-count"
-            >{yearEventIds.length} event{yearEventIds.length !== 1
-              ? "s"
-              : ""}</span
+        <h2 class="year-heading">
+          <button
+            type="button"
+            class="year-header"
+            onclick={() => toggleYear(year)}
+            aria-expanded={expandedYears[year]}
+            aria-controls={yearEventsId(year)}
           >
-          <span class="expand-icon">{expandedYears[year] ? "▼" : "►"}</span>
-        </div>
+            <span class="section-title">{year}</span>
+            <span class="event-count"
+              >{yearEventIds.length} event{yearEventIds.length !== 1
+                ? "s"
+                : ""}</span
+            >
+            <span class="expand-icon">{expandedYears[year] ? "▼" : "►"}</span>
+          </button>
+        </h2>
 
         {#if expandedYears[year]}
-          <div class="year-events">
+          <div class="year-events" id={yearEventsId(year)}>
             {#each dataLoadedByYear[year] as event (event.id)}
               <div class="event-card-container">
                 <EventCard
@@ -142,21 +149,32 @@
     margin-bottom: 8px;
   }
 
+  .year-heading {
+    margin: 0;
+    font-size: 1em;
+    font-weight: normal;
+  }
+
   .year-header {
+    width: 100%;
     display: flex;
     align-items: center;
     padding: 4px 0;
     cursor: pointer;
     user-select: none;
+    border: 0;
     border-bottom: 1px solid #eaecf0;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
   }
 
   .year-header:hover {
     background-color: #f8f9fa;
   }
 
-  .year-header h2 {
-    margin: 0;
+  .section-title {
     font-size: 1.3em;
     font-weight: normal;
     flex-grow: 1;

--- a/website/src/lib/sliding_pane/SameLocationEvents.svelte
+++ b/website/src/lib/sliding_pane/SameLocationEvents.svelte
@@ -16,10 +16,14 @@
       return acc;
     }, {})
   );
+  const sortedMonthEntries = $derived(
+    Object.entries(eventIdsByMonth).sort(([monthA], [monthB]) =>
+      monthA.localeCompare(monthB)
+    )
+  );
 
   $effect(() => {
     if (sameLocationEvents) {
-      console.log(sameLocationEvents);
       loadEventList();
     }
   });
@@ -106,7 +110,7 @@
   {:else if Object.keys(eventIdsByMonth).length === 0}
     <div class="no-events">No events found at this location.</div>
   {:else}
-    {#each Object.entries(eventIdsByMonth).sort( ([monthA], [monthB]) => monthA.localeCompare(monthB) ) as [month, monthEventIds]}
+    {#each sortedMonthEntries as [month, monthEventIds] (month)}
       <div class="month-section">
         <div
           class="month-header"
@@ -126,7 +130,7 @@
 
         {#if expandedMonths[month]}
           <div class="month-events">
-            {#each dataLoadedByMonth[month] as event}
+            {#each dataLoadedByMonth[month] as event (event.id)}
               <div class="event-card-container">
                 <EventCard
                   entry={event}

--- a/website/src/lib/sliding_pane/SameLocationEvents.svelte
+++ b/website/src/lib/sliding_pane/SameLocationEvents.svelte
@@ -203,7 +203,7 @@
   .same-location-events {
     padding: 16px;
     overflow-y: auto;
-    color: #222;
+    color: var(--ln-color-text);
     font-family: sans-serif;
   }
 
@@ -211,20 +211,20 @@
     margin-bottom: 8px;
     font-size: 1.8em;
     font-weight: normal;
-    border-bottom: 1px solid #a2a9b1;
+    border-bottom: 1px solid var(--ln-color-border-strong);
     padding-bottom: 0.2em;
   }
 
   .date-info {
     margin-bottom: 16px;
-    color: #54595d;
+    color: var(--ln-color-text-muted);
     font-size: 1.1em;
   }
 
   .loading,
   .no-events {
     padding: 12px 0;
-    color: #72777d;
+    color: var(--ln-color-text-subtle);
   }
 
   .month-section {
@@ -245,7 +245,7 @@
     cursor: pointer;
     user-select: none;
     border: 0;
-    border-bottom: 1px solid #eaecf0;
+    border-bottom: 1px solid var(--ln-color-border-muted);
     background: none;
     color: inherit;
     font: inherit;
@@ -253,7 +253,7 @@
   }
 
   .month-header:hover {
-    background-color: #f8f9fa;
+    background-color: var(--ln-color-surface-muted);
   }
 
   .section-title {
@@ -264,12 +264,12 @@
 
   .event-count {
     margin-right: 8px;
-    color: #72777d;
+    color: var(--ln-color-text-subtle);
     font-size: 0.85em;
   }
 
   .expand-icon {
-    color: #72777d;
+    color: var(--ln-color-text-subtle);
     font-size: 0.8em;
     width: 16px;
     text-align: center;
@@ -281,10 +281,10 @@
 
   .event-card-container {
     margin-bottom: 8px;
-    border: 1px solid #eaeaea;
-    border-radius: 6px;
+    border: 1px solid var(--ln-color-border-muted);
+    border-radius: var(--ln-radius-lg);
     padding: 12px;
-    background-color: white;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background-color: var(--ln-color-surface);
+    box-shadow: var(--ln-shadow-sm);
   }
 </style>

--- a/website/src/lib/sliding_pane/SameLocationEvents.svelte
+++ b/website/src/lib/sliding_pane/SameLocationEvents.svelte
@@ -3,18 +3,42 @@
   import { getEventsById } from "../data/events_data";
   import { normalizeMapEntryInfo } from "../data/mapEntries.svelte";
   import { appState } from "../appState.svelte";
+
+  /**
+   * @typedef {{ year: string | number, month: string | number }} EventMonthDate
+   * @typedef {{ event_id: string, start_date: EventMonthDate, [key: string]: unknown }} SameLocationEvent
+   * @typedef {{ id: string, start_date: string, [key: string]: unknown }} NormalizedEvent
+   * @typedef {Record<string, string[]>} EventIdsByMonth
+   * @typedef {Record<string, boolean>} ExpandedMonths
+   * @typedef {Record<string, NormalizedEvent[]>} DataLoadedByMonth
+   * @typedef {Record<string, NormalizedEvent>} EventInfosById
+   */
+
+  /** @type {{ sameLocationEvents: SameLocationEvent[] }} */
   let { sameLocationEvents } = $props();
   let loadingEvents = $state(true);
+
+  /** @type {ExpandedMonths} */
   let expandedMonths = $state({});
+
+  /** @type {DataLoadedByMonth} */
   let dataLoadedByMonth = $state({});
 
   const eventIdsByMonth = $derived(
-    sameLocationEvents.reduce((acc, event) => {
-      const monthKey = `${event.start_date.year}-${event.start_date.month}`;
-      acc[monthKey] = acc[monthKey] || [];
-      acc[monthKey].push(event.event_id);
-      return acc;
-    }, {})
+    sameLocationEvents.reduce(
+      /**
+       * @param {EventIdsByMonth} acc
+       * @param {SameLocationEvent} event
+       * @returns {EventIdsByMonth}
+       */
+      (acc, event) => {
+        const monthKey = `${event.start_date.year}-${event.start_date.month}`;
+        acc[monthKey] = acc[monthKey] || [];
+        acc[monthKey].push(event.event_id);
+        return acc;
+      },
+      /** @type {EventIdsByMonth} */ ({})
+    )
   );
   const sortedMonthEntries = $derived(
     Object.entries(eventIdsByMonth).sort(([monthA], [monthB]) =>
@@ -46,13 +70,26 @@
     loadingEvents = false;
   }
 
+  /** @param {string[]} allEventIds */
   async function loadAllEvents(allEventIds) {
     const rawEventInfos = await getEventsById(allEventIds);
-    const eventInfos = rawEventInfos.map(normalizeMapEntryInfo);
-    const eventInfosById = eventInfos.reduce((acc, event) => {
-      acc[event.id] = event;
-      return acc;
-    }, {});
+    /** @type {NormalizedEvent[]} */
+    const eventInfos = rawEventInfos.map((event) =>
+      /** @type {NormalizedEvent} */ (normalizeMapEntryInfo(event))
+    );
+    /** @type {EventInfosById} */
+    const eventInfosById = eventInfos.reduce(
+      /**
+       * @param {EventInfosById} acc
+       * @param {NormalizedEvent} event
+       * @returns {EventInfosById}
+       */
+      (acc, event) => {
+        acc[event.id] = event;
+        return acc;
+      },
+      /** @type {EventInfosById} */ ({})
+    );
 
     Object.entries(eventIdsByMonth).forEach(([month, monthEventIds]) => {
       dataLoadedByMonth[month] = monthEventIds
@@ -62,6 +99,7 @@
     });
   }
 
+  /** @param {string} month */
   async function toggleMonth(month) {
     const toggledValue = !expandedMonths[month];
     if (toggledValue && !dataLoadedByMonth[month]) {
@@ -70,18 +108,31 @@
     expandedMonths[month] = toggledValue;
   }
 
+  /**
+   * @param {string} month
+   * @returns {Promise<NormalizedEvent[]>}
+   */
   async function loadEventData(month) {
     const eventsByMonth = await getEventsById(eventIdsByMonth[month]);
     return eventsByMonth
-      .map(normalizeMapEntryInfo)
+      .map((event) => /** @type {NormalizedEvent} */ (normalizeMapEntryInfo(event)))
       .sort((a, b) => a.start_date.localeCompare(b.start_date));
   }
 
   // Format month for display (YYYY-MM to Month YYYY)
+  /** @param {string} monthKey */
   function formatMonth(monthKey) {
     const [year, month] = monthKey.split("-");
-    const date = new Date(year, parseInt(month) - 1, 1);
+    const date = new Date(Number(year), parseInt(month) - 1, 1);
     return date.toLocaleString("default", { month: "long", year: "numeric" });
+  }
+
+  /**
+   * @param {string} month
+   * @returns {string}
+   */
+  function monthEventsId(month) {
+    return `same-location-events-month-${month}-events`;
   }
 </script>
 
@@ -112,24 +163,26 @@
   {:else}
     {#each sortedMonthEntries as [month, monthEventIds] (month)}
       <div class="month-section">
-        <div
-          class="month-header"
-          onclick={() => toggleMonth(month)}
-          onkeydown={(e) => e.key === "Enter" && toggleMonth(month)}
-          role="button"
-          tabindex="0"
-        >
-          <h2>{formatMonth(month)}</h2>
-          <span class="event-count"
-            >{monthEventIds.length} event{monthEventIds.length !== 1
-              ? "s"
-              : ""}</span
+        <h2 class="month-heading">
+          <button
+            type="button"
+            class="month-header"
+            onclick={() => toggleMonth(month)}
+            aria-expanded={expandedMonths[month]}
+            aria-controls={monthEventsId(month)}
           >
-          <span class="expand-icon">{expandedMonths[month] ? "▼" : "►"}</span>
-        </div>
+            <span class="section-title">{formatMonth(month)}</span>
+            <span class="event-count"
+              >{monthEventIds.length} event{monthEventIds.length !== 1
+                ? "s"
+                : ""}</span
+            >
+            <span class="expand-icon">{expandedMonths[month] ? "▼" : "►"}</span>
+          </button>
+        </h2>
 
         {#if expandedMonths[month]}
-          <div class="month-events">
+          <div class="month-events" id={monthEventsId(month)}>
             {#each dataLoadedByMonth[month] as event (event.id)}
               <div class="event-card-container">
                 <EventCard
@@ -178,21 +231,32 @@
     margin-bottom: 8px;
   }
 
+  .month-heading {
+    margin: 0;
+    font-size: 1em;
+    font-weight: normal;
+  }
+
   .month-header {
+    width: 100%;
     display: flex;
     align-items: center;
     padding: 4px 0;
     cursor: pointer;
     user-select: none;
+    border: 0;
     border-bottom: 1px solid #eaecf0;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
   }
 
   .month-header:hover {
     background-color: #f8f9fa;
   }
 
-  .month-header h2 {
-    margin: 0;
+  .section-title {
     font-size: 1.3em;
     font-weight: normal;
     flex-grow: 1;

--- a/website/src/lib/sliding_pane/SlidingPane.svelte
+++ b/website/src/lib/sliding_pane/SlidingPane.svelte
@@ -137,8 +137,8 @@
   }
 
   .pane {
-    background: white;
-    box-shadow: 2px 0 10px rgba(0, 0, 0, 0.2);
+    background: var(--ln-color-surface);
+    box-shadow: var(--ln-shadow-pane);
     overflow-y: auto;
     display: flex;
     flex-direction: column;
@@ -180,9 +180,9 @@
     .pane {
       width: 100% !important;
       max-height: 100dvh;
-      border-top-left-radius: 16px;
-      border-top-right-radius: 16px;
-      box-shadow: 0 -4px 18px rgba(0, 0, 0, 0.22);
+      border-top-left-radius: var(--ln-radius-2xl);
+      border-top-right-radius: var(--ln-radius-2xl);
+      box-shadow: var(--ln-shadow-pane-mobile);
       overflow: hidden;
     }
 

--- a/website/src/lib/sliding_pane/SlidingPane.svelte
+++ b/website/src/lib/sliding_pane/SlidingPane.svelte
@@ -55,25 +55,6 @@
         : "")
   );
 
-  // Reference to the iframe element
-  let wikiIframe = $state(null);
-
-  $inspect(wikiUrl);
-
-  // Focus the iframe whenever wikiUrl changes
-  $effect(() => {
-    if (
-      wikiIframe &&
-      wikiUrl !== "about:blank" &&
-      appState.paneTab === "wikipedia"
-    ) {
-      console.log("focusing iframe");
-      setTimeout(() => {
-        wikiIframe.focus();
-      }, 400); // Small delay to ensure iframe has loaded
-    }
-  });
-
   // ===== EVENT HANDLERS =====
 
   // Toggle expanded mode (works for both desktop and mobile)
@@ -119,10 +100,7 @@
     <div class="pane-content">
       {#if appState.paneTab === "wikipedia" && appState.wikiPage}
         <iframe
-          bind:this={wikiIframe}
           id="wiki-iframe"
-          tabindex="-2"
-          aria-hidden="true"
           title="Wikipedia Content"
           src={wikiUrl}
           frameborder="0"

--- a/website/src/lib/sliding_pane/SlidingPane.svelte
+++ b/website/src/lib/sliding_pane/SlidingPane.svelte
@@ -6,12 +6,15 @@
   import { onMount } from "svelte";
   import { appState, uiState } from "../appState.svelte";
 
-  let isNarrowScreen = $state(
-    typeof window !== "undefined" && window.innerWidth <= 768
-  );
-  let expanded = $state(window.innerWidth <= 768); // fullscreen by default on narrow screens
+  const mobileSheetHeights = {
+    half: "50dvh",
+    full: "100dvh",
+  };
+
+  let isNarrowScreen = $state(false);
+  let expanded = $state(false);
+  let sheetState = $state("half");
   const normalWidth = "400px"; // Default width for desktop
-  const normalHeight = "35vh"; // Default height for mobile
 
   // ===== STATE VARIABLES =====
   let isInitialRender = $state(true);
@@ -33,10 +36,8 @@
     isInitialRender
       ? "0px"
       : isNarrowScreen
-        ? expanded
-          ? "100vh"
-          : normalHeight
-        : "100vh"
+        ? mobileSheetHeights[sheetState]
+        : "100dvh"
   );
 
   // Generate Wikipedia URL based on device and width
@@ -57,11 +58,11 @@
 
   // ===== EVENT HANDLERS =====
 
-  // Toggle expanded mode (works for both desktop and mobile)
   function closePane() {
     appState.wikiPage = null;
     appState.selectedMarkerId = null;
     appState.paneTab = "wikipedia";
+    sheetState = "half";
   }
 
   // Open in new tab
@@ -71,16 +72,16 @@
     }
   }
 
-  // Handle window resize
   function handleResize() {
     if (typeof window !== "undefined") {
-      // Update mobile detection
       isNarrowScreen = window.innerWidth <= 768;
     }
   }
 
   // ===== LIFECYCLE =====
   onMount(() => {
+    handleResize();
+
     // Trigger the initial animation after a small delay
     setTimeout(() => {
       isInitialRender = false;
@@ -93,9 +94,19 @@
   onresize={handleResize}
 />
 
-<div class="pane-container">
-  <div class="pane" style="width: {actualWidth}; height: {actualHeight};">
-    <SlidingPaneHeader bind:expanded {openWikiPageInNewTab} {closePane} />
+<div class="pane-container" class:mobile={isNarrowScreen}>
+  <div
+    class="pane"
+    data-sheet-state={sheetState}
+    style="width: {actualWidth}; height: {actualHeight};"
+  >
+    <SlidingPaneHeader
+      bind:expanded
+      bind:sheetState
+      {isNarrowScreen}
+      {openWikiPageInNewTab}
+      {closePane}
+    />
 
     <div class="pane-content">
       {#if appState.paneTab === "wikipedia" && appState.wikiPage}
@@ -122,6 +133,7 @@
 <style>
   .pane-container {
     display: flex;
+    height: 100%;
   }
 
   .pane {
@@ -134,6 +146,7 @@
       width 0.3s ease,
       height 0.3s ease;
     z-index: 100;
+    pointer-events: auto;
   }
 
   .pane-content {
@@ -153,10 +166,25 @@
 
   /* Mobile styles */
   @media (max-width: 768px) {
+    .pane-container.mobile {
+      position: fixed;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      display: block;
+      height: auto;
+      z-index: 900;
+      pointer-events: none;
+    }
+
     .pane {
       width: 100% !important;
-      border-top-left-radius: 12px;
-      border-top-right-radius: 12px;
+      max-height: 100dvh;
+      border-top-left-radius: 16px;
+      border-top-right-radius: 16px;
+      box-shadow: 0 -4px 18px rgba(0, 0, 0, 0.22);
+      overflow: hidden;
     }
+
   }
 </style>

--- a/website/src/lib/sliding_pane/SlidingPaneHeader.svelte
+++ b/website/src/lib/sliding_pane/SlidingPaneHeader.svelte
@@ -4,9 +4,17 @@
 
   let {
     expanded = $bindable(false),
+    sheetState = $bindable("half"),
+    isNarrowScreen = false,
     closePane,
     openWikiPageInNewTab,
   } = $props();
+
+  let mobileExpanded = $derived(sheetState === "full");
+
+  function toggleMobileSheetState() {
+    sheetState = mobileExpanded ? "half" : "full";
+  }
 </script>
 
 <div class="pane-header">
@@ -70,23 +78,24 @@
         class="icon"
       />
     </button>
-    <!-- Mobile Expand Button (hidden on desktop) -->
-    <button
-      type="button"
-      class="icon-button expand-button mobile-only"
-      class:active={expanded}
-      onclick={() => (expanded = !expanded)}
-      title={expanded ? "Shrink pane" : "Expand pane"}
-      aria-label={expanded ? "Shrink pane" : "Expand pane"}
-    >
-      <img
-        src={expanded
-          ? `${basePath}icons/shrink.svg`
-          : `${basePath}icons/expand-vertical.svg`}
-        alt={expanded ? "Shrink pane" : "Expand pane"}
-        class="icon"
-      />
-    </button>
+    {#if isNarrowScreen}
+      <button
+        type="button"
+        class="icon-button expand-button"
+        class:active={mobileExpanded}
+        onclick={toggleMobileSheetState}
+        title={mobileExpanded ? "Shrink pane" : "Expand pane"}
+        aria-label={mobileExpanded ? "Shrink pane" : "Expand pane"}
+      >
+        <img
+          src={mobileExpanded
+            ? `${basePath}icons/shrink.svg`
+            : `${basePath}icons/expand-vertical.svg`}
+          alt={mobileExpanded ? "Shrink pane" : "Expand pane"}
+          class="icon"
+        />
+      </button>
+    {/if}
     <button
       type="button"
       class="close-button"
@@ -181,20 +190,11 @@
     display: block;
   }
 
-  .mobile-only {
-    display: none;
-  }
-
   /* Mobile styles */
   @media (max-width: 768px) {
     /* Hide desktop-only elements on mobile */
     .desktop-only {
       display: none;
-    }
-
-    /* Show mobile-only elements on mobile */
-    .mobile-only {
-      display: block;
     }
   }
 </style>

--- a/website/src/lib/sliding_pane/SlidingPaneHeader.svelte
+++ b/website/src/lib/sliding_pane/SlidingPaneHeader.svelte
@@ -11,19 +11,25 @@
 
 <div class="pane-header">
   {#if appState.paneTab === "wikipedia" || appState.paneTab === "events"}
-    <div class="tab-buttons">
+    <div class="tab-buttons" role="tablist" aria-label="Sliding pane content">
       <button
+        type="button"
+        role="tab"
         class="tab-button"
         class:active={appState.paneTab === "wikipedia"}
         onclick={() => (appState.paneTab = "wikipedia")}
+        aria-selected={appState.paneTab === "wikipedia"}
         aria-label="Wikipedia tab"
       >
         Wikipedia
       </button>
       <button
+        type="button"
+        role="tab"
         class="tab-button"
         class:active={appState.paneTab === "events"}
         onclick={() => (appState.paneTab = "events")}
+        aria-selected={appState.paneTab === "events"}
         aria-label="Events tab"
       >
         Events
@@ -32,20 +38,24 @@
   {/if}
 
   <div class="header-buttons">
-    <button
-      class="icon-button external-link-button"
-      onclick={openWikiPageInNewTab}
-      title="Open in new tab"
-      aria-label="Open in new tab"
-    >
-      <img
-        src={`${basePath}icons/external-link.svg`}
-        alt="Open in new tab"
-        class="icon"
-      />
-    </button>
+    {#if appState.wikiPage}
+      <button
+        type="button"
+        class="icon-button external-link-button"
+        onclick={openWikiPageInNewTab}
+        title="Open in new tab"
+        aria-label="Open in new tab"
+      >
+        <img
+          src={`${basePath}icons/external-link.svg`}
+          alt="Open in new tab"
+          class="icon"
+        />
+      </button>
+    {/if}
     <!-- Desktop Expand Button (hidden on mobile) -->
     <button
+      type="button"
       class="icon-button expand-button desktop-only"
       class:active={expanded}
       onclick={() => (expanded = !expanded)}
@@ -62,6 +72,7 @@
     </button>
     <!-- Mobile Expand Button (hidden on desktop) -->
     <button
+      type="button"
       class="icon-button expand-button mobile-only"
       class:active={expanded}
       onclick={() => (expanded = !expanded)}
@@ -76,7 +87,12 @@
         class="icon"
       />
     </button>
-    <button class="close-button" onclick={closePane} aria-label="Close panel">
+    <button
+      type="button"
+      class="close-button"
+      onclick={closePane}
+      aria-label="Close panel"
+    >
       &times;
     </button>
   </div>

--- a/website/src/lib/sliding_pane/SlidingPaneHeader.svelte
+++ b/website/src/lib/sliding_pane/SlidingPaneHeader.svelte
@@ -113,10 +113,10 @@
     justify-content: space-between;
     align-items: center;
     padding: 0.2rem;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--ln-color-border-muted);
     position: sticky;
     top: 0;
-    background: white;
+    background: var(--ln-color-surface);
     z-index: 1;
   }
 
@@ -133,16 +133,17 @@
     border-bottom: 2px solid transparent;
     cursor: pointer;
     font-weight: 500;
-    transition: all 0.2s ease;
+    color: var(--ln-color-text);
+    transition: all var(--ln-transition-base);
   }
 
   .tab-button:hover {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: var(--ln-color-surface-hover);
   }
 
   .tab-button.active {
-    border-bottom: 2px solid #1a73e8;
-    color: #1a73e8;
+    border-bottom: 2px solid var(--ln-color-primary);
+    color: var(--ln-color-primary);
   }
 
   .header-buttons {
@@ -160,7 +161,7 @@
     padding: 0.5rem;
     min-width: 36px;
     height: 36px;
-    border-radius: 4px;
+    border-radius: var(--ln-radius-lg);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -168,7 +169,7 @@
 
   .icon-button:hover,
   .close-button:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--ln-color-surface-hover);
   }
 
   .icon {
@@ -182,7 +183,7 @@
   }
 
   .expand-button.active {
-    color: #1a73e8;
+    color: var(--ln-color-primary);
   }
 
   /* Hide/show based on device type */
@@ -195,6 +196,12 @@
     /* Hide desktop-only elements on mobile */
     .desktop-only {
       display: none;
+    }
+
+    .icon-button,
+    .close-button,
+    .tab-button {
+      min-height: var(--ln-space-touch);
     }
   }
 </style>


### PR DESCRIPTION
## Summary

A batch of UX, accessibility, and visual-consistency improvements across the map and the sliding pane / menu UI. The work is grouped into focused commits so it can be reviewed thematically.

### Map markers, popups, and dots
- Use `dialog` semantics for map popups and improve their focus/keyboard behavior.
- Use a single focusable control per map marker so keyboard navigation is predictable.
- Mobile pane no longer covers points of interest: map centering reserves space when the bottom pane is open.
- Clicking a small dot (no picture/title) now flies in and zooms two levels onto the region, so dots act as a navigational hint instead of dead pixels.
- Disclosure buttons on event cards are now accessible buttons, and the "See N other events" handler:
  - stops the click from bubbling to the surrounding marker/popup,
  - sets `sameLocationEvents` before flipping the pane tab so the pane has data on first render,
  - clears lingering `wikiSection` and drops the marker selection when switching panes.

### Menus and search
- Label date and dropdown controls for screen readers.
- Improve search-menu loading ergonomics (clearer loading state, less flicker).
- General responsiveness/feedback polish for menu interactions.

### Sliding pane
- Clean up header actions in the sliding pane.
- Polish menu feedback and the map attribution rendering.

### Visual system
- Introduce a shared set of design tokens (color, radius, shadow, spacing, transition) and migrate existing components to use them, so the look stays consistent as more UI is added.

### Commits

- `559b047` Tighten same-location events button behavior
- `864cef1` Zoom in when clicking small map dots
- `489981d` Add shared visual system tokens
- `fd14bc6` Use one focusable control per map marker
- `aa08372` Improve mobile pane map positioning
- `2f2ccda` Use dialog semantics for map popups
- `d40d310` Polish menu feedback and map attribution
- `6e2161a` Clean up sliding pane header actions
- `4c209ed` Use accessible event disclosure buttons
- `a06de6b` Label date and dropdown controls
- `1e88e9b` Improve search menu loading ergonomics
- `09690ee` Improve map and menu UX responsiveness

## Test plan

- [ ] Desktop: hover/click event and place markers; tab through them with the keyboard, ensure only one focusable control per marker and that popups receive focus correctly.
- [ ] Desktop: click small dots and confirm the map flies in and zooms ~2 levels onto the region.
- [ ] Mobile (or narrow viewport): open a marker, confirm the map re-centers so the selected location isn't hidden behind the sliding pane.
- [ ] Event card: click "See N other events" and confirm the pane opens with events listed immediately, no Wikipedia page lingers, and the originating marker is no longer selected; verify the click doesn't also trigger the marker's Wikipedia open.
- [ ] Menus: open the date picker, the dropdown, and the search bar with a screen reader; verify labels are announced.
- [ ] Search: trigger a slow query and verify the loading state appears cleanly.
- [ ] Verify the page generally still looks correct across light/dark themes after the visual token migration.


Made with [Cursor](https://cursor.com)