### PR TITLE
Fix map tooltip placement and event card popups

### DIFF
--- a/website/src/lib/map/EventCard.svelte
+++ b/website/src/lib/map/EventCard.svelte
@@ -238,7 +238,7 @@
 <div
   class="event-card"
   style={constrainHeight
-    ? `max-height: ${uiGlobals.isTouchDevice ? "230px" : "230px"}; font-size: ${fontSize}px;`
+    ? `max-height: 276px; font-size: ${fontSize}px;`
     : ""}
 >
   {#if displayPage}
@@ -479,14 +479,25 @@
       var(--ln-shadow-sm);
   }
 
+  .event-card-section.other-events-button {
+    padding-top: 2px;
+    margin-top: 4px;
+  }
+
   .event-card-section.other-events-button button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     background-color: var(--ln-color-surface);
     border: 1px solid var(--ln-color-primary);
-    border-radius: var(--ln-radius-md);
+    border-radius: var(--ln-radius-sm);
     color: var(--ln-color-primary);
-    padding: 6px 14px;
-    min-height: 36px;
+    padding: 2px 10px;
+    min-height: 0;
+    line-height: 1.25;
+    font-size: 13px;
     transition: all var(--ln-transition-base);
+    box-shadow: var(--ln-shadow-sm);
   }
 
   .event-card-section.other-events-button button:hover {
@@ -501,9 +512,13 @@
   }
 
   @media (max-width: 768px) {
-    .event-card-section.go-to-event-button button,
-    .event-card-section.other-events-button button {
+    .event-card-section.go-to-event-button button {
       min-height: var(--ln-space-touch);
+    }
+
+    .event-card-section.other-events-button button {
+      min-height: 36px;
+      padding: 4px 12px;
     }
   }
 </style>

--- a/website/src/lib/map/MapPopup.svelte
+++ b/website/src/lib/map/MapPopup.svelte
@@ -1,7 +1,7 @@
 <script>
   // Reactive state
   import { uiGlobals } from "../appState.svelte";
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
   import { portal } from "svelte-portal";
 
   const generatedPopupId = $props.id();
@@ -102,17 +102,25 @@
         portalTarget = document.getElementById("main");
       }
 
-      // Ensure we have valid element references before updating position
-      if (!popupElement || !triggerElement) {
-        // Wait for next tick to allow elements to be rendered
-        requestAnimationFrame(() => {
-          if (popupElement && triggerElement) {
-            updateTooltipPosition();
-          }
-        });
-      } else {
-        updateTooltipPosition();
+      if (popupElement) {
+        popupElement.style.removeProperty("visibility");
       }
+
+      // Wait for the popup snippet to render before measuring, otherwise the
+      // popup is sized to its empty wrapper and ends up overlapping the trigger.
+      tick().then(() => {
+        if (!isOpen) return;
+        if (popupElement && triggerElement) {
+          updateTooltipPosition();
+        } else {
+          requestAnimationFrame(() => {
+            if (isOpen && popupElement && triggerElement) {
+              updateTooltipPosition();
+            }
+          });
+        }
+      });
+
       clearTimeout(visibilityTimeout);
       visibilityTimeout = setTimeout(() => {
         visibility = "visible";
@@ -120,7 +128,7 @@
     } else if (!isOpen && wasOpen) {
       clearTimeout(visibilityTimeout);
       visibility = "hidden";
-      if (!enterable && popupElement) {
+      if (popupElement) {
         popupElement.style.visibility = "hidden";
       }
     }
@@ -243,8 +251,9 @@
 
   function onMouseLeave() {
     if (enterable) {
+      clearTimeout(closeTimeout);
       closeTimeout = setTimeout(() => {
-        isHovered = false;
+        closeHoverPopup();
       }, 200);
     } else {
       closeHoverPopup();
@@ -339,7 +348,9 @@
     aria-labelledby={popupLabelledby}
     aria-hidden={!isOpen}
   >
-    {@render popupContent(isOpen)}
+    {#if isOpen}
+      {@render popupContent(isOpen)}
+    {/if}
   </div>
 {:else}
   <div
@@ -362,7 +373,9 @@
     aria-labelledby={popupLabelledby}
     aria-hidden={!isOpen}
   >
-    {@render popupContent(isOpen)}
+    {#if isOpen}
+      {@render popupContent(isOpen)}
+    {/if}
   </div>
 {/if}
 
@@ -414,7 +427,7 @@
   :global(.map-popup) {
     position: fixed;
     width: 350px;
-    max-height: 260px;
+    max-height: 312px;
     overflow: visible;
     padding: 0;
 


### PR DESCRIPTION
## Summary
- **Event cards** (constrained height on the map): increase max height (~20%), tighten the “See X other events” control, and keep a smaller touch target for that button on narrow screens while leaving “See in context” at the full touch size.
- **MapPopup**: unmount popup content when `!isOpen` so nested UI cannot outlive the close; clear the enterable close timer before rescheduling; use `closeHoverPopup()` after the grace delay; always set `visibility: hidden` on the shell when closing; raise `.map-popup` max-height to match the taller card.
- **Placement**: call `tick()` before the first `getBoundingClientRect()` so height reflects rendered content; avoids the popup sitting on top of the marker after conditional rendering.

## Notes
`MenuDropdown.svelte` had unrelated local edits; they were left out of this branch (still stashed only for the branch switch—actually we restored it; user’s `ux-improvements` may need nothing).


Made with [Cursor](https://cursor.com)