### PR TITLE
Hide empty share status in menu dropdown

### DIFF
--- a/website/src/lib/map/MarkerIcon.svelte
+++ b/website/src/lib/map/MarkerIcon.svelte
@@ -103,7 +103,9 @@
   triggerClass="map-marker-trigger"
   onTriggerActivate={onClick}
   enterable={entry.isEvent || uiGlobals.isTouchDevice}
-  alwaysOpen={uiGlobals.isTouchDevice && entry.displayClass === "selected"}
+  alwaysOpen={uiGlobals.isTouchDevice &&
+    entry.displayClass === "selected" &&
+    entry.isEvent}
   visibilityDelay={entry.isEvent ? 0 : 100}
   keepWithinMap={true}
 >

--- a/website/src/lib/menu/MenuDropdown.svelte
+++ b/website/src/lib/menu/MenuDropdown.svelte
@@ -180,9 +180,11 @@
       >
         Share the link for the current view
       </span>
-      <div class="share-status {shareStatusType}" role="status" aria-live="polite">
-        {shareStatus}
-      </div>
+      {#if shareStatus}
+        <div class="share-status {shareStatusType}" role="status" aria-live="polite">
+          {shareStatus}
+        </div>
+      {/if}
       <span
         onclick={() => {
           appState.paneTab = "about";
@@ -337,7 +339,6 @@
   }
 
   .share-status {
-    min-height: 20px;
     padding: 0 16px 8px;
     color: var(--ln-color-success);
     font-size: 13px;


### PR DESCRIPTION
## Summary
- Only show the share feedback row in the menu when `shareStatus` has a message.
- Remove the `min-height: 20px` on `.share-status` so the dropdown does not reserve empty space when idle.
- On mobile, do not keep the place marker preview popup open when selected — the Wikipedia pane already shows the article and the popup overlapped it. Event markers still show the event card popup when selected.

## Test plan
- [ ] Open the menu → confirm no extra gap below “Share the link…” when no share message is shown.
- [ ] Use “Share the link for the current view” → confirm success/error text appears and layout looks correct.
- [ ] After the status clears, confirm the gap goes away again.
- [ ] **Mobile:** Tap a place marker → Wikipedia pane opens, no preview popup over the map/pane.
- [ ] **Mobile:** Tap an event marker → event card popup still appears when selected.